### PR TITLE
Add submitter for submitted and unapproved workflows

### DIFF
--- a/components/WorkflowPanel.tsx
+++ b/components/WorkflowPanel.tsx
@@ -12,6 +12,7 @@ const workflowForPanel = Prisma.validator<Prisma.WorkflowArgs>()({
   include: {
     creator: true,
     assignee: true,
+    submitter: true,
     nextReview: true,
   },
 })
@@ -51,11 +52,16 @@ const WorkflowPanel = ({ workflow }: Props): React.ReactElement => {
             `Held since ${prettyDate(String(workflow.heldAt))} · `}
           {workflow.form && `${workflow.form.name} · `}
           {workflow.assignee ? (
-            <>Assigned to {workflow?.assignee.name}</>
+            workflow.submitter ? (
+              `Submitted by ${
+                workflow?.submitter?.name || workflow?.submittedBy
+              } · `
+            ) : (
+              `Assigned to ${workflow?.assignee.name} · `
+            )
           ) : (
-            <>Started by {workflow?.creator.name} · Unassigned</>
-          )}{" "}
-          ·{" "}
+            `Started by ${workflow?.creator.name} · Unassigned · `
+          )}
           <Link href={`/workflows/${workflow.id}`}>
             <a className="lbh-link lbh-link--muted">Overview</a>
           </Link>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,6 +19,7 @@ const workflowWithRelations = Prisma.validator<Prisma.WorkflowArgs>()({
   include: {
     creator: true,
     assignee: true,
+    submitter: true,
     nextReview: true,
   },
 })
@@ -88,6 +89,7 @@ export const getServerSideProps: GetServerSideProps = async req => {
     include: {
       creator: true,
       assignee: true,
+      submitter: true,
       nextReview: true,
     },
     // put things that are in progress below the rest


### PR DESCRIPTION
- Display "Submitted by" in meta data of workflow panel
- Update tests to have explicit assertions - although it's not needed, added for readability https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-get-variants-as-assertions
- Update index page to include `submitter`

![image](https://user-images.githubusercontent.com/42817036/133104305-4b5a2932-a7b0-40fa-9541-3e1162c8e2d5.png)
