### PR TITLE
Add send to brokerage or direct payments to panel authorisation

### DIFF
--- a/components/Approve.test.tsx
+++ b/components/Approve.test.tsx
@@ -38,6 +38,6 @@ describe("ApproveDialog", () => {
     fireEvent.click(screen.getByText("Authorise"))
     expect(screen.getByText("Panel authorisation"))
     expect(screen.getByText("Do you want to authorise this work?"))
-    expect(screen.getByText("Yes, the panel has authorised this"))
+    expect(screen.getByText("Yes, send to brokerage"))
   })
 })

--- a/components/MilestoneTimeline.test.tsx
+++ b/components/MilestoneTimeline.test.tsx
@@ -78,7 +78,7 @@ describe("MilestoneTimeline", () => {
     )
     expect(screen.getByText("Submitted for approval by foo"))
     expect(screen.getByText("Approved by foo"))
-    expect(screen.getByText("Sent to brokerage by foo"))
+    expect(screen.getByText("Authorised and sent to brokerage by foo"))
   })
 
   it("shows approved workflows sent to direct payments correctly", () => {
@@ -106,7 +106,7 @@ describe("MilestoneTimeline", () => {
     )
     expect(screen.getByText("Submitted for approval by foo"))
     expect(screen.getByText("Approved by foo"))
-    expect(screen.getByText("Sent to direct payments team by foo"))
+    expect(screen.getByText("Authorised and sent to direct payments team by foo"))
   })
 
   it("shows a held workflow correctly", () => {

--- a/components/MilestoneTimeline.test.tsx
+++ b/components/MilestoneTimeline.test.tsx
@@ -4,7 +4,7 @@ import MilestoneTimeline, {
 } from "./MilestoneTimeline"
 import { mockWorkflowWithExtras } from "../fixtures/workflows"
 import { mockRevisionWithActor } from "../fixtures/revisions"
-import { Workflow } from "@prisma/client"
+import { Workflow, FinanceType } from "@prisma/client"
 
 const mockWorkflowWithRevisions = {
   ...mockWorkflowWithExtras,
@@ -53,7 +53,7 @@ describe("MilestoneTimeline", () => {
     expect(screen.getByText("Reassessment started by Firstname Surname"))
   })
 
-  it("shows approvals correctly", () => {
+  it("shows approved workflows sent to brokerage correctly", () => {
     render(
       <MilestoneTimeline
         workflow={
@@ -63,6 +63,7 @@ describe("MilestoneTimeline", () => {
             panelApprover: {
               name: "foo",
             },
+            sentTo: FinanceType.Brokerage,
             managerApprovedAt: "2021-08-04T10:11:40.593Z" as unknown as Date,
             managerApprover: {
               name: "foo",
@@ -77,7 +78,35 @@ describe("MilestoneTimeline", () => {
     )
     expect(screen.getByText("Submitted for approval by foo"))
     expect(screen.getByText("Approved by foo"))
-    expect(screen.getByText("Authorised by foo"))
+    expect(screen.getByText("Sent to brokerage by foo"))
+  })
+
+  it("shows approved workflows sent to direct payments correctly", () => {
+    render(
+      <MilestoneTimeline
+        workflow={
+          {
+            ...mockData,
+            panelApprovedAt: "2021-08-04T10:11:40.593Z" as unknown as Date,
+            panelApprover: {
+              name: "foo",
+            },
+            sentTo: FinanceType.DirectPayments,
+            managerApprovedAt: "2021-08-04T10:11:40.593Z" as unknown as Date,
+            managerApprover: {
+              name: "foo",
+            },
+            submittedAt: "2021-08-04T10:11:40.593Z" as unknown as Date,
+            submitter: {
+              name: "foo",
+            },
+          } as unknown as WorkflowForMilestoneTimeline
+        }
+      />
+    )
+    expect(screen.getByText("Submitted for approval by foo"))
+    expect(screen.getByText("Approved by foo"))
+    expect(screen.getByText("Sent to direct payments team by foo"))
   })
 
   it("shows a held workflow correctly", () => {

--- a/components/MilestoneTimeline.tsx
+++ b/components/MilestoneTimeline.tsx
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client"
+import { Prisma, FinanceType } from "@prisma/client"
 import Link from "next/link"
 import { useMemo } from "react"
 import { displayEditorNames, prettyDateAndTime } from "../lib/formatters"
@@ -88,8 +88,11 @@ const MilestoneTimeline = ({ workflow }: Props): React.ReactElement => {
             />
           </svg>
           <h3 className="lbh-body">
-            Authorised by{" "}
-            {workflow?.panelApprover?.name || workflow.panelApprovedBy}
+            Sent to{" "}
+            {workflow.sentTo === FinanceType.Brokerage
+              ? "brokerage"
+              : "direct payments team"}{" "}
+            by {workflow?.panelApprover?.name || workflow.panelApprovedBy}
           </h3>
           <p className="lbh-body-xs">
             {prettyDateAndTime(String(workflow.panelApprovedAt))}

--- a/components/MilestoneTimeline.tsx
+++ b/components/MilestoneTimeline.tsx
@@ -88,7 +88,7 @@ const MilestoneTimeline = ({ workflow }: Props): React.ReactElement => {
             />
           </svg>
           <h3 className="lbh-body">
-            Sent to{" "}
+            Authorised and sent to{" "}
             {workflow.sentTo === FinanceType.Brokerage
               ? "brokerage"
               : "direct payments team"}{" "}

--- a/cypress/integration/browseAndInspect.js
+++ b/cypress/integration/browseAndInspect.js
@@ -34,7 +34,7 @@ describe("Browse and inspect workflows", () => {
     cy.contains("a", "Start reassessment")
 
     // milestones
-    cy.contains("Sent to brokerage by Fake User")
+    cy.contains("Authorised and sent to brokerage by Fake User")
     cy.contains("Approved by Fake User")
     cy.contains("Submitted for approval by Fake User")
     cy.contains("Started by Fake User")

--- a/cypress/integration/browseAndInspect.js
+++ b/cypress/integration/browseAndInspect.js
@@ -34,7 +34,7 @@ describe("Browse and inspect workflows", () => {
     cy.contains("a", "Start reassessment")
 
     // milestones
-    cy.contains("Authorised by Fake User")
+    cy.contains("Sent to brokerage by Fake User")
     cy.contains("Approved by Fake User")
     cy.contains("Submitted for approval by Fake User")
     cy.contains("Started by Fake User")

--- a/cypress/integration/newWorkflow.js
+++ b/cypress/integration/newWorkflow.js
@@ -140,6 +140,6 @@ describe("New workflow", () => {
     cy.contains("Yes, send to brokerage").click()
     cy.contains("button", "Submit").click()
 
-    cy.contains("Sent to brokerage by Fake Panel Approver").should("be.visible")
+    cy.contains("Authorised and sent to brokerage by Fake Panel Approver").should("be.visible")
   })
 })

--- a/cypress/integration/newWorkflow.js
+++ b/cypress/integration/newWorkflow.js
@@ -137,9 +137,9 @@ describe("New workflow", () => {
 
     cy.contains("h2", "Panel authorisation").should("be.visible")
 
-    cy.contains("Yes, the panel has authorised this").click()
+    cy.contains("Yes, send to brokerage").click()
     cy.contains("button", "Submit").click()
 
-    cy.contains("Authorised by Fake Panel Approver").should("be.visible")
+    cy.contains("Sent to brokerage by Fake Panel Approver").should("be.visible")
   })
 })

--- a/fixtures/workflows.ts
+++ b/fixtures/workflows.ts
@@ -29,6 +29,7 @@ export const mockWorkflow: Workflow = {
   managerApprovedBy: null,
   panelApprovedAt: null,
   panelApprovedBy: null,
+  sentTo: null,
   discardedAt: null,
   discardedBy: null,
   heldAt: null,
@@ -83,6 +84,7 @@ export const mockSubmittedWorkflowWithExtras: MockWorkflowWithExtras = {
   panelApprover: null,
   panelApprovedAt: null,
   panelApprovedBy: null,
+  sentTo: null,
 }
 
 export const mockManagerApprovedWorkflowWithExtras: MockWorkflowWithExtras = {
@@ -93,4 +95,5 @@ export const mockManagerApprovedWorkflowWithExtras: MockWorkflowWithExtras = {
   panelApprover: null,
   panelApprovedAt: null,
   panelApprovedBy: null,
+  sentTo: null,
 }

--- a/pages/api/workflows/[id]/approval.ts
+++ b/pages/api/workflows/[id]/approval.ts
@@ -31,6 +31,8 @@ export const handler = async (
             .status(400)
             .json({ error: "You're not authorised to perform that action" })
 
+        const { sentTo } = JSON.parse(req.body)
+
         updatedWorkflow = await prisma.workflow.update({
           where: {
             id: id as string,
@@ -38,6 +40,7 @@ export const handler = async (
           data: {
             panelApprovedAt: new Date(),
             panelApprovedBy: req.session.user.email,
+            sentTo: sentTo,
           },
         })
       } else {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,11 @@ enum WorkflowType {
   Reassessment
 }
 
+enum FinanceType {
+  DirectPayments
+  Brokerage
+}
+
 model Workflow {
   id                String       @id @default(cuid())
   type              WorkflowType @default(Assessment)
@@ -43,6 +48,7 @@ model Workflow {
   panelApprovedAt   DateTime?
   panelApprovedBy   String?
   panelApprover     User?        @relation(name: "panelApprover", fields: [panelApprovedBy], references: [email])
+  sentTo            FinanceType?
   // 5. review self-join
   previousReview    Workflow?    @relation("WorkflowToWorkflow", fields: [workflowId], references: [id])
   nextReview        Workflow?    @relation("WorkflowToWorkflow")

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,4 +1,4 @@
-const { PrismaClient } = require("@prisma/client")
+const { PrismaClient, FinanceType } = require("@prisma/client")
 const { DateTime } = require("luxon")
 const prisma = new PrismaClient()
 
@@ -112,6 +112,7 @@ const main = async () => {
         managerApprovedBy: "fake.user@hackney.gov.uk",
         panelApprovedAt: "2021-08-01T00:00:00.000Z",
         panelApprovedBy: "fake.user@hackney.gov.uk",
+        sentTo: FinanceType.Brokerage,
       },
     ],
   })


### PR DESCRIPTION
## What

- Update options for panel authorisation to be: send to brokerage or send to direct payments.
- Update milestone timeline to remove "Authorised by" and replace with "Sent to brokerage by" and "Sent to direct payments".

### Choosing send to direct payments

https://user-images.githubusercontent.com/42817036/134474663-b12866da-e05b-4938-a85a-ce5b7971569a.mov

### Choosing send to brokerage

https://user-images.githubusercontent.com/42817036/134474652-e9d7191e-acd9-46ce-8793-ef7fa1b6d86c.mov

