### PR TITLE
Improve test coverage

### DIFF
--- a/lib/auth/test-functions.tsx
+++ b/lib/auth/test-functions.tsx
@@ -1,306 +1,287 @@
-import {ReactElement} from "react";
-import {sign} from "jsonwebtoken";
-import {getLoginUrl, getSession, UserNotLoggedIn} from "./session";
-import {render} from "@testing-library/react";
-import {SessionContext} from "./SessionContext";
-import {GetServerSideProps, GetServerSidePropsContext, NextApiRequest, NextApiResponse} from "next";
+import { ReactElement } from "react"
+import { sign } from "jsonwebtoken"
+import { getLoginUrl, getSession, UserNotLoggedIn } from "./session"
+import { render } from "@testing-library/react"
+import { SessionContext } from "./SessionContext"
 import {
-  mockSession,
-  mockSessionApprover,
-  mockSessionNotInPilot,
-  mockSessionPanelApprover
-} from "../../fixtures/session";
-import {ParsedUrlQuery} from "querystring";
-import {UserSession} from "./types";
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  NextApiRequest,
+  NextApiResponse,
+} from "next"
+import { mockSession } from "../../fixtures/session"
+import { ParsedUrlQuery } from "querystring"
+import { UserSession } from "./types"
 
-export const dateToUnix = (date: Date): number => Math.floor(date.getTime() / 1000);
+export const dateToUnix = (date: Date): number =>
+  Math.floor(date.getTime() / 1000)
 
 interface MakeTokenInput {
-  sub?: string;
+  sub?: string
   email?: string
-  iss?: string;
-  name?: string;
-  groups?: Array<string>;
-  iat?: Date,
+  iss?: string
+  name?: string
+  groups?: Array<string>
+  iat?: Date
 }
 
-export const makeToken = (
-  {
-    sub = '49516349857314',
-    email = 'test@example.com',
-    iss = 'Hackney',
-    name = 'example user',
-    groups = ['test-group'],
-    iat = new Date(),
-  }: MakeTokenInput
-): string => sign(
-  {sub, email, iss, name, groups, iat: dateToUnix(iat)},
-  process.env.HACKNEY_AUTH_TOKEN_SECRET,
-);
+export const makeToken = ({
+  sub = "49516349857314",
+  email = "test@example.com",
+  iss = "Hackney",
+  name = "example user",
+  groups = ["test-group"],
+  iat = new Date(),
+}: MakeTokenInput): string =>
+  sign(
+    { sub, email, iss, name, groups, iat: dateToUnix(iat) },
+    process.env.HACKNEY_AUTH_TOKEN_SECRET
+  )
 
 export interface MakeNextApiRequestInput {
-  method?: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH';
-  query?: ParsedUrlQuery;
-  url?: string;
-  session?: UserSession;
-  body?: unknown;
+  method?:
+    | "GET"
+    | "HEAD"
+    | "POST"
+    | "PUT"
+    | "DELETE"
+    | "CONNECT"
+    | "OPTIONS"
+    | "TRACE"
+    | "PATCH"
+  query?: ParsedUrlQuery
+  url?: string
+  session?: UserSession
+  body?: unknown
   headers?: {
-    [key: string]: string;
-  };
+    [key: string]: string
+  }
 }
 
-export const makeNextApiRequest =
-  ({
-     method = 'GET',
-     query = {},
-     url = '/',
-     session = null,
-     body = null,
-     headers = {},
-   }: MakeNextApiRequestInput): NextApiRequest => {
-    const request = {
-      method,
-      url,
-      query,
-      headers,
-    } as unknown as NextApiRequest;
+export const makeNextApiRequest = ({
+  method = "GET",
+  query = {},
+  url = "/",
+  session = null,
+  body = null,
+  headers = {},
+}: MakeNextApiRequestInput): NextApiRequest => {
+  const request = {
+    method,
+    url,
+    query,
+    headers,
+  } as unknown as NextApiRequest
 
-    if (session) request['user'] = session;
-    if (body) request['body'] = JSON.stringify(body);
+  if (session) request["user"] = session
+  if (body) request["body"] = JSON.stringify(body)
 
-    return request;
-  };
+  return request
+}
 
 export interface MakeGetServerSidePropsContextInput {
-  resolvedUrl?: string;
-  method?: string;
-  token?: string;
-  query?: ParsedUrlQuery;
-  referer?: string;
+  resolvedUrl?: string
+  method?: string
+  token?: string
+  query?: ParsedUrlQuery
+  referer?: string
+  user?: UserSession
 }
 
-export const makeGetServerSidePropsContext =
-  ({
-     resolvedUrl = '/url',
-     method = 'GET',
-     token = makeToken({}),
-     query = {},
-     referer = null,
-   }: MakeGetServerSidePropsContextInput): GetServerSidePropsContext => {
-    const context = {
-      params: {},
-      query,
-      req: {
-        method,
-        headers: {},
-        cookies: {},
-      },
-      res: {},
-      resolvedUrl,
-    };
+export const makeGetServerSidePropsContext = ({
+  resolvedUrl = "/url",
+  method = "GET",
+  token = makeToken({}),
+  query = {},
+  referer = null,
+  user = mockSession,
+}: MakeGetServerSidePropsContextInput): GetServerSidePropsContext => {
+  const context = {
+    params: {},
+    query,
+    req: {
+      method,
+      headers: {},
+      cookies: {},
+      user,
+    },
+    res: {},
+    resolvedUrl,
+  }
 
-    if (token) context.req.cookies[process.env.HACKNEY_AUTH_COOKIE_NAME] = token;
-    if (referer) context.req.headers["referer"] = referer;
+  if (token) context.req.cookies[process.env.HACKNEY_AUTH_COOKIE_NAME] = token
+  if (referer) context.req.headers["referer"] = referer
 
-    return context as unknown as GetServerSidePropsContext;
-  };
+  return context as unknown as GetServerSidePropsContext
+}
 
-export const renderWithSession = (components: ReactElement, session: UserSession = mockSession): void => {
+export const renderWithSession = (
+  components: ReactElement,
+  session: UserSession = mockSession
+): void => {
   render(
     <SessionContext.Provider value={session}>
       {components}
     </SessionContext.Provider>
   )
-};
+}
 
 export type HttpMethod =
-  'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH';
+  | "GET"
+  | "HEAD"
+  | "POST"
+  | "PUT"
+  | "DELETE"
+  | "CONNECT"
+  | "OPTIONS"
+  | "TRACE"
+  | "PATCH"
 
 export const testApiHandlerUnsupportedMethods = (
-  apiHandler: (
-    req: NextApiRequest,
-    res: NextApiResponse
-  ) => Promise<void>,
-  allowedMethods: Array<HttpMethod>,
+  apiHandler: (req: NextApiRequest, res: NextApiResponse) => Promise<void>,
+  allowedMethods: Array<HttpMethod>
 ): void => {
-  const allMethods: Array<HttpMethod> = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT', 'OPTIONS', 'TRACE', 'PATCH'];
-  const methods: Array<HttpMethod> = allMethods
-    .filter((method: HttpMethod) => !allowedMethods.includes(method));
+  const allMethods: Array<HttpMethod> = [
+    "GET",
+    "HEAD",
+    "POST",
+    "PUT",
+    "DELETE",
+    "CONNECT",
+    "OPTIONS",
+    "TRACE",
+    "PATCH",
+  ]
+  const methods: Array<HttpMethod> = allMethods.filter(
+    (method: HttpMethod) => !allowedMethods.includes(method)
+  )
 
-  describe('when called with unsupported http method', () => {
+  describe("when called with unsupported http method", () => {
     methods.forEach(method => {
-      const mockJson = jest.fn();
+      const mockJson = jest.fn()
 
       const response = {
-        status: jest.fn().mockReturnValue({json: mockJson}),
+        status: jest.fn().mockReturnValue({ json: mockJson }),
         json: mockJson,
       } as unknown as NextApiResponse
 
       describe(`when called with a ${method} request`, () => {
-        beforeAll(async () =>
-          await apiHandler(makeNextApiRequest({
-            method,
-          }), response));
+        beforeAll(
+          async () =>
+            await apiHandler(
+              makeNextApiRequest({
+                method,
+              }),
+              response
+            )
+        )
 
-        test('a 405 http status code is returned', () => {
+        test("a 405 http status code is returned", () => {
           expect(response.status).toHaveBeenCalledWith(405)
-        });
-        test('an error message is provided', () => {
+        })
+        test("an error message is provided", () => {
           expect(response.json).toHaveBeenCalledWith({
             error: `${method} not supported on this endpoint`,
           })
-        });
-      });
+        })
+      })
     })
-  });
-};
+  })
+}
 
-export const testGetServerSidePropsAuthRedirect = (
-  getServerSideProps: GetServerSideProps,
-  redirectWhenNotInPilotGroup: boolean | string = true,
-  redirectWhenOnlyApprover: boolean | string = true,
-  redirectWhenOnlyPanelApprover: boolean | string = true,
-): void => {
-  describe('authentication redirects', function () {
-    describe("when user not in the pilot group", () => {
-      if (redirectWhenNotInPilotGroup) {
-        it("returns a redirect to the root page", async () => {
-          ;(getSession as jest.Mock).mockResolvedValueOnce(mockSessionNotInPilot);
-          const response = await getServerSideProps(makeGetServerSidePropsContext({}))
+interface TestGetServerSidePropsAuthRedirectInput {
+  getServerSideProps: GetServerSideProps
+  tests: Array<{
+    name: string
+    session: UserSession
+    redirect?: string | boolean
+    context?: GetServerSidePropsContext
+  }>
+}
 
-          expect(response).toHaveProperty(
-            "redirect",
-            {
-              destination: (typeof redirectWhenNotInPilotGroup === 'string') ?
-                redirectWhenNotInPilotGroup : '/',
-              statusCode: 307,
-            },
-          );
-        })
+export const testGetServerSidePropsAuthRedirect = ({
+  getServerSideProps,
+  tests,
+}: TestGetServerSidePropsAuthRedirectInput): void => {
+  describe("authentication redirects", function () {
+    tests.forEach(test => {
+      describe(`when ${test.name}`, () => {
+        if (test.redirect) {
+          if (typeof test.redirect === "string") {
+            it(`returns a redirect to ${test.redirect}`, async () => {
+              ;(getSession as jest.Mock).mockResolvedValueOnce(test.session)
 
-        it("returns a redirect to the referring page", async () => {
-          ;(getSession as jest.Mock).mockResolvedValueOnce(mockSessionNotInPilot);
-          const response = await getServerSideProps(makeGetServerSidePropsContext({
-            referer: 'test-referer',
-          }));
+              const response = await getServerSideProps(
+                test.context ? test.context : makeGetServerSidePropsContext({})
+              )
 
-          expect(response).toHaveProperty(
-            "redirect",
-            {
-              destination: (typeof redirectWhenNotInPilotGroup === 'string') ?
-                redirectWhenNotInPilotGroup : 'test-referer',
-              statusCode: 307,
-            }
-          )
-        })
-      } else {
-        it("does not redirect the user away", async () => {
-          ;(getSession as jest.Mock).mockResolvedValueOnce(mockSessionNotInPilot);
-          const response = await getServerSideProps(makeGetServerSidePropsContext({}))
+              expect(response).toHaveProperty("redirect", {
+                destination: test.redirect,
+                statusCode: 307,
+              })
+            })
+          } else {
+            it("returns a redirect to the root page", async () => {
+              ;(getSession as jest.Mock).mockResolvedValueOnce(test.session)
 
-          expect(response).not.toHaveProperty("redirect");
-          expect(response).toHaveProperty("props");
-        })
-      }
-    });
+              const response = await getServerSideProps(
+                test.context ? test.context : makeGetServerSidePropsContext({})
+              )
 
-    describe('when user is only an approver', () => {
-      if (redirectWhenOnlyApprover) {
-        it("returns a redirect to the root page", async () => {
-          ;(getSession as jest.Mock).mockResolvedValueOnce(mockSessionApprover);
-          const response = await getServerSideProps(makeGetServerSidePropsContext({}))
+              expect(response).toHaveProperty("redirect", {
+                destination: "/",
+                statusCode: 307,
+              })
+            })
 
-          expect(response).toHaveProperty(
-            "redirect",
-            {
-              destination: (typeof redirectWhenOnlyApprover === 'string') ?
-                redirectWhenOnlyApprover : '/',
-              statusCode: 307,
-            }
-          )
-        })
+            it("returns a redirect to the referring page", async () => {
+              ;(getSession as jest.Mock).mockResolvedValueOnce(test.session)
 
-        it("returns a redirect to the referring page", async () => {
-          ;(getSession as jest.Mock).mockResolvedValueOnce(mockSessionApprover);
-          const response = await getServerSideProps(makeGetServerSidePropsContext({
-            referer: 'test-referer',
-          }));
+              const response = await getServerSideProps(
+                test.context
+                  ? ({
+                      ...test.context,
+                      req: { headers: { referer: "test-referer" } },
+                    } as GetServerSidePropsContext)
+                  : makeGetServerSidePropsContext({})
+              )
 
-          expect(response).toHaveProperty(
-            "redirect",
-            {
-              destination: (typeof redirectWhenOnlyApprover === 'string') ?
-                redirectWhenOnlyApprover : 'test-referer',
-              statusCode: 307,
-            }
-          )
-        })
-      } else {
-        it("does not redirect the user away", async () => {
-          ;(getSession as jest.Mock).mockResolvedValueOnce(mockSessionApprover);
-          const response = await getServerSideProps(makeGetServerSidePropsContext({}))
+              expect(response).toHaveProperty("redirect", {
+                destination: "test-referer",
+                statusCode: 307,
+              })
+            })
+          }
+        } else {
+          it("does not redirect the user away", async () => {
+            ;(getSession as jest.Mock).mockResolvedValueOnce(test.session)
 
-          expect(response).not.toHaveProperty("redirect");
-          expect(response).toHaveProperty("props");
-        })
-      }
-    });
+            const response = await getServerSideProps(
+              test.context ? test.context : makeGetServerSidePropsContext({})
+            )
 
-    describe('when user is only a panel approver', () => {
-      if (redirectWhenOnlyPanelApprover) {
-        it("returns a redirect to the root page", async () => {
-          ;(getSession as jest.Mock).mockResolvedValueOnce(mockSessionPanelApprover);
-          const response = await getServerSideProps(makeGetServerSidePropsContext({}))
-
-          expect(response).toHaveProperty(
-            "redirect",
-            {
-              destination: (typeof redirectWhenOnlyPanelApprover === 'string') ?
-                redirectWhenOnlyPanelApprover : '/',
-              statusCode: 307,
-            }
-          )
-        })
-
-        it("returns a redirect to the referring page", async () => {
-          ;(getSession as jest.Mock).mockResolvedValueOnce(mockSessionPanelApprover);
-          const response = await getServerSideProps(makeGetServerSidePropsContext({
-            referer: 'test-referer',
-          }));
-
-          expect(response).toHaveProperty(
-            "redirect",
-            {
-              destination: (typeof redirectWhenOnlyPanelApprover === 'string') ?
-                redirectWhenOnlyPanelApprover : 'test-referer',
-              statusCode: 307,
-            }
-          )
-        })
-      } else {
-        it("does not redirect the user away", async () => {
-          ;(getSession as jest.Mock).mockResolvedValueOnce(mockSessionPanelApprover);
-          const response = await getServerSideProps(makeGetServerSidePropsContext({}))
-
-          expect(response).not.toHaveProperty("redirect");
-          expect(response).toHaveProperty("props");
-        })
-      }
-    });
+            expect(response).not.toHaveProperty("redirect")
+            expect(response).toHaveProperty("props")
+          })
+        }
+      })
+    })
 
     describe("when user not authenticated", () => {
-      it("returns a redirect to the sign-in page", async () => {
-        ;(getSession as jest.Mock).mockRejectedValueOnce(new UserNotLoggedIn)
-        ;(getLoginUrl as jest.Mock).mockReturnValueOnce('auth-server');
-        const response = await getServerSideProps(makeGetServerSidePropsContext({}))
+      it("returns a redirect to the auth server", async () => {
+        ;(getSession as jest.Mock).mockRejectedValueOnce(new UserNotLoggedIn())
+        ;(getLoginUrl as jest.Mock).mockReturnValueOnce("auth-server")
+        const response = await getServerSideProps(
+          makeGetServerSidePropsContext({})
+        )
 
         expect(response).toHaveProperty(
           "redirect",
           expect.objectContaining({
-            destination: expect.stringMatching('auth-server'),
+            destination: expect.stringMatching("auth-server"),
           })
         )
       })
-    });
-  });
-};
+    })
+  })
+}

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -61,7 +61,7 @@ export const prettyNextSteps = (
   const all = nextSteps.map(nextStep =>
     nextStepOptions.find(o => o.id === nextStep.nextStepOptionId)
   )
-  const now = all.filter(o => o.waitForApproval).length
+  const now = all.filter(o => o?.waitForApproval).length
   const later = all.length - now
 
   if (now || later)

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -87,7 +87,7 @@ export const generateFinishSchema = (
           .oneOf(nextStepOptions.map(o => o.id))
           .required(),
         note: Yup.string().when("nextStepOptionId", {
-          is: id => nextStepOptions.find(o => o.id === id).handoverNote,
+          is: id => nextStepOptions.find(o => o.id === id)?.handoverNote,
           then: Yup.string()
             .required("You must give a note")
             .min(5, "That note is too short"),

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -1,4 +1,4 @@
-import {NextApiRequest, NextApiResponse} from "next"
+import { NextApiRequest, NextApiResponse } from "next"
 import { apiHandler } from "../../../lib/apiHelpers"
 import prisma from "../../../lib/prisma"
 import { EditableUserValues } from "../../../types"
@@ -10,7 +10,7 @@ export const handler = async (
 ): Promise<void> => {
   switch (req.method) {
     case "PATCH": {
-      if (!req['user']?.approver)
+      if (!req["user"]?.approver)
         return res
           .status(400)
           .json({ error: "You're not authorised to perform that action" })
@@ -52,7 +52,9 @@ export const handler = async (
     }
 
     default: {
-      res.status(405).json({ error: "Method not supported on this endpoint" })
+      res
+        .status(405)
+        .json({ error: `${req.method} not supported on this endpoint` })
     }
   }
 }

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -12,7 +12,7 @@ export const handler = async (
     case "PATCH": {
       if (!req["user"]?.approver)
         return res
-          .status(400)
+          .status(401)
           .json({ error: "You're not authorised to perform that action" })
 
       const values: EditableUserValues = JSON.parse(req.body)

--- a/pages/reviews/[id]/steps/[stepId].tsx
+++ b/pages/reviews/[id]/steps/[stepId].tsx
@@ -44,6 +44,16 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
   async ({ query, req }) => {
     const { id, stepId } = query
 
+    if (!req["user"]?.inPilot) {
+      return {
+        props: {},
+        redirect: {
+          destination: `/workflows/${id}`,
+          statusCode: 307,
+        },
+      }
+    }
+
     const workflow = await prisma.workflow.findUnique({
       where: {
         id: id as string,

--- a/pages/reviews/[id]/steps/[stepId].tsx
+++ b/pages/reviews/[id]/steps/[stepId].tsx
@@ -52,7 +52,7 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
         previousReview: true,
       },
     })
-    const form = (await forms()).find(form => form.id === workflow.formId)
+    const form = (await forms()).find(form => form.id === workflow?.formId)
 
     // redirect if workflow or form doesn't exist
     if (!workflow || !form)
@@ -70,8 +70,8 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
       // 2a. is the workflow submitted AND is the user an approver?
       // 2b. is the workflow manager approved AND is the user a panel approver?
       if (
-        !(status === Status.Submitted && req['user']?.approver) &&
-        !(status === Status.ManagerApproved && req['user']?.panelApprover)
+        !(status === Status.Submitted && req["user"]?.approver) &&
+        !(status === Status.ManagerApproved && req["user"]?.panelApprover)
       )
         return {
           props: {},
@@ -88,6 +88,7 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
         props: {},
         redirect: {
           destination: `/workflows/${workflow.id}/steps/${stepId}`,
+          statusCode: 307,
         },
       }
 

--- a/pages/workflows/[id]/finish.tsx
+++ b/pages/workflows/[id]/finish.tsx
@@ -19,7 +19,7 @@ import NextStepFields from "../../../components/NextStepFields"
 import { prettyNextSteps, prettyResidentName } from "../../../lib/formatters"
 import { csrfFetch } from "../../../lib/csrfToken"
 import { protectRoute } from "../../../lib/protectRoute"
-import {pilotGroup} from "../../../config/allowedGroups";
+import { pilotGroup } from "../../../config/allowedGroups"
 
 const workflowWithRelations = Prisma.validator<Prisma.WorkflowArgs>()({
   include: {
@@ -32,9 +32,11 @@ type WorkflowWithRelations = Prisma.WorkflowGetPayload<
   form?: FormT
 }
 
-const FinishWorkflowPage = (
+interface Props {
   workflow: WorkflowWithRelations
-): React.ReactElement => {
+}
+
+const FinishWorkflowPage = ({ workflow }: Props): React.ReactElement => {
   const { push, query } = useRouter()
   const { data: resident } = useResident(workflow.socialCareId)
   const { data: users } = useUsers()
@@ -297,16 +299,18 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
 
     return {
       props: {
-        ...JSON.parse(
-          JSON.stringify({
-            ...workflow,
-            form: (await forms()).find(form => form.id === workflow.formId),
-          })
-        ),
+        workflow: {
+          ...JSON.parse(
+            JSON.stringify({
+              ...workflow,
+              form: (await forms()).find(form => form.id === workflow.formId),
+            })
+          ),
+        },
       },
     }
   },
-  [pilotGroup],
+  [pilotGroup]
 )
 
 export default FinishWorkflowPage

--- a/pages/workflows/[id]/steps/[stepId].tsx
+++ b/pages/workflows/[id]/steps/[stepId].tsx
@@ -21,7 +21,7 @@ import useResident from "../../../../hooks/useResident"
 import Link from "next/link"
 import { csrfFetch } from "../../../../lib/csrfToken"
 import { protectRoute } from "../../../../lib/protectRoute"
-import { pilotGroup } from "../../../../config/allowedGroups";
+import { pilotGroup } from "../../../../config/allowedGroups"
 
 interface Props {
   workflow: Workflow
@@ -144,13 +144,14 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
       // 2a. is the workflow submitted AND is the user an approver?
       // 2b. is the workflow manager approved AND is the user a panel approver?
       if (
-        !(status === Status.Submitted && req['user']?.approver) &&
-        !(status === Status.ManagerApproved && req['user']?.panelApprover)
+        !(status === Status.Submitted && req["user"]?.approver) &&
+        !(status === Status.ManagerApproved && req["user"]?.panelApprover)
       )
         return {
           props: {},
           redirect: {
             destination: `/workflows/${workflow.id}`,
+            statusCode: 307,
           },
         }
     }
@@ -161,6 +162,7 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
         props: {},
         redirect: {
           destination: `/reviews/${workflow.id}/steps/${stepId}`,
+          statusCode: 307,
         },
       }
 
@@ -171,7 +173,7 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
       },
     }
   },
-  [pilotGroup],
+  [pilotGroup]
 )
 
 export default StepPage

--- a/pages/workflows/[id]/steps/[stepId].tsx
+++ b/pages/workflows/[id]/steps/[stepId].tsx
@@ -21,7 +21,6 @@ import useResident from "../../../../hooks/useResident"
 import Link from "next/link"
 import { csrfFetch } from "../../../../lib/csrfToken"
 import { protectRoute } from "../../../../lib/protectRoute"
-import { pilotGroup } from "../../../../config/allowedGroups"
 
 interface Props {
   workflow: Workflow
@@ -122,6 +121,16 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
   async ({ query, req }) => {
     const { id, stepId } = query
 
+    if (!req["user"]?.inPilot) {
+      return {
+        props: {},
+        redirect: {
+          destination: `/workflows/${id}`,
+          statusCode: 307,
+        },
+      }
+    }
+
     const workflow = await prisma.workflow.findUnique({
       where: {
         id: id as string,
@@ -172,8 +181,7 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
         allSteps: await allStepsConfig(),
       },
     }
-  },
-  [pilotGroup]
+  }
 )
 
 export default StepPage

--- a/pages/workflows/[id]/steps/index.tsx
+++ b/pages/workflows/[id]/steps/index.tsx
@@ -16,7 +16,7 @@ import { Prisma } from "@prisma/client"
 import forms from "../../../../config/forms"
 import useResident from "../../../../hooks/useResident"
 import { protectRoute } from "../../../../lib/protectRoute"
-import { pilotGroup } from "../../../../config/allowedGroups";
+import { pilotGroup } from "../../../../config/allowedGroups"
 
 const workflowWithRelations = Prisma.validator<Prisma.WorkflowArgs>()({
   include: {
@@ -146,7 +146,7 @@ const TaskListPage = ({ workflow }: Props): React.ReactElement => {
 
 export const getServerSideProps: GetServerSideProps = protectRoute(
   async ({ query, req }) => {
-    const { id } = query;
+    const { id } = query
 
     const workflow = await prisma.workflow.findUnique({
       where: {
@@ -181,6 +181,7 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
           props: {},
           redirect: {
             destination: `/workflows/${workflow.id}`,
+            statusCode: 307,
           },
         }
     }
@@ -196,7 +197,7 @@ export const getServerSideProps: GetServerSideProps = protectRoute(
       },
     }
   },
-  [pilotGroup],
+  [pilotGroup]
 )
 
 export default TaskListPage

--- a/pagesTest/api/users/index.test.ts
+++ b/pagesTest/api/users/index.test.ts
@@ -1,8 +1,12 @@
 import { handler } from "../../../pages/api/users"
-import { NextApiRequest, NextApiResponse } from "next"
+import { NextApiResponse } from "next"
 import prisma from "../../../lib/prisma"
 import { mockUser } from "../../../fixtures/users"
-import { testApiHandlerUnsupportedMethods } from "../../../lib/auth/test-functions"
+import {
+  makeNextApiRequest,
+  testApiHandlerUnsupportedMethods,
+} from "../../../lib/auth/test-functions"
+import { mockSession } from "../../../fixtures/session"
 
 jest.mock("../../../lib/prisma", () => ({
   user: {
@@ -26,12 +30,13 @@ describe("when the HTTP method is GET", () => {
   })
 
   it("filters historic users if historic query param is not provided", async () => {
-    const request = {
-      method: "GET",
-      session: { user: mockUser },
-    } as unknown as NextApiRequest
-
-    await handler(request, response)
+    await handler(
+      makeNextApiRequest({
+        method: "GET",
+        session: mockSession,
+      }),
+      response
+    )
 
     expect(prisma.user.findMany).toBeCalledWith({
       where: expect.objectContaining({
@@ -42,13 +47,14 @@ describe("when the HTTP method is GET", () => {
   })
 
   it("doesn't filter historic users if historic query param is provided", async () => {
-    const request = {
-      method: "GET",
-      session: { user: mockUser },
-      query: { historic: true },
-    } as unknown as NextApiRequest
-
-    await handler(request, response)
+    await handler(
+      makeNextApiRequest({
+        method: "GET",
+        session: mockSession,
+        query: { historic: "true" },
+      }),
+      response
+    )
 
     expect(prisma.user.findMany).toBeCalledWith({
       where: expect.objectContaining({
@@ -59,12 +65,13 @@ describe("when the HTTP method is GET", () => {
   })
 
   it("returns users", async () => {
-    const request = {
-      method: "GET",
-      session: { user: mockUser },
-    } as unknown as NextApiRequest
-
-    await handler(request, response)
+    await handler(
+      makeNextApiRequest({
+        method: "GET",
+        session: mockSession,
+      }),
+      response
+    )
 
     expect(response.json).toBeCalledWith([mockUser])
   })

--- a/pagesTest/api/users/index.test.ts
+++ b/pagesTest/api/users/index.test.ts
@@ -1,13 +1,16 @@
 import { handler } from "../../../pages/api/users"
-import {NextApiRequest, NextApiResponse} from "next"
+import { NextApiRequest, NextApiResponse } from "next"
 import prisma from "../../../lib/prisma"
 import { mockUser } from "../../../fixtures/users"
+import { testApiHandlerUnsupportedMethods } from "../../../lib/auth/test-functions"
 
 jest.mock("../../../lib/prisma", () => ({
   user: {
     findMany: jest.fn(),
   },
 }))
+
+testApiHandlerUnsupportedMethods(handler, ["GET", "PATCH"])
 
 describe("when the HTTP method is GET", () => {
   let response
@@ -64,25 +67,5 @@ describe("when the HTTP method is GET", () => {
     await handler(request, response)
 
     expect(response.json).toBeCalledWith([mockUser])
-  })
-})
-
-describe("when invalid HTTP methods", () => {
-  ;["POST", "PUT", "DELETE"].forEach(method => {
-    const response = {
-      status: jest.fn().mockImplementation(() => response),
-      json: jest.fn(),
-    } as unknown as NextApiResponse
-
-    it(`returns 405 for ${method}`, async () => {
-      const request = { method: method } as unknown as NextApiRequest
-
-      await handler(request, response)
-
-      expect(response.status).toHaveBeenCalledWith(405)
-      expect(response.json).toHaveBeenCalledWith({
-        error: "Method not supported on this endpoint",
-      })
-    })
   })
 })

--- a/pagesTest/api/users/index.test.ts
+++ b/pagesTest/api/users/index.test.ts
@@ -6,11 +6,12 @@ import {
   makeNextApiRequest,
   testApiHandlerUnsupportedMethods,
 } from "../../../lib/auth/test-functions"
-import { mockSession } from "../../../fixtures/session"
+import { mockSession, mockSessionApprover } from "../../../fixtures/session"
 
 jest.mock("../../../lib/prisma", () => ({
   user: {
     findMany: jest.fn(),
+    update: jest.fn(),
   },
 }))
 
@@ -74,5 +75,118 @@ describe("when the HTTP method is GET", () => {
     )
 
     expect(response.json).toBeCalledWith([mockUser])
+  })
+})
+
+describe("when the HTTP method is PATCH", () => {
+  describe("when the user isn't approver", () => {
+    it("returns 401 and error message", async () => {
+      const response = {
+        status: jest.fn().mockImplementation(() => response),
+        json: jest.fn(),
+      } as unknown as NextApiResponse
+
+      await handler(
+        makeNextApiRequest({
+          method: "PATCH",
+          session: mockSession,
+        }),
+        response
+      )
+
+      expect(response.status).toBeCalledWith(401)
+      expect(response.json).toBeCalledWith({
+        error: "You're not authorised to perform that action",
+      })
+    })
+  })
+
+  describe("when the user is an approver", () => {
+    const response = {
+      status: jest.fn().mockImplementation(() => response),
+      json: jest.fn(),
+    } as unknown as NextApiResponse
+    const mockUser1 = {
+      ...mockUser,
+      id: "idOfUserWithChangedApprover",
+      email: "test@example.com",
+    }
+    const mockUser2 = {
+      ...mockUser,
+      id: "idOfUserWithNoTeam",
+      email: "another.test@example.com",
+    }
+
+    beforeAll(async () => {
+      ;(prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        ...mockUser1,
+        approver: !mockUser1.approver,
+      })
+      ;(prisma.user.update as jest.Mock).mockResolvedValueOnce({
+        ...mockUser2,
+        team: null,
+      })
+
+      await handler(
+        makeNextApiRequest({
+          method: "PATCH",
+          session: mockSessionApprover,
+          body: {
+            idOfUserWithChangedApprover: {
+              email: mockUser1.email,
+              team: mockUser1.team,
+              approver: !mockUser1.approver,
+              panelApprover: mockUser1.panelApprover,
+            },
+            idOfUserWithNoTeam: {
+              email: mockUser2.email,
+              approver: mockUser2.approver,
+              panelApprover: mockUser2.panelApprover,
+            },
+          },
+        }),
+        response
+      )
+    })
+
+    it("calls Prisma to update each user", () => {
+      expect(prisma.user.update).toBeCalledWith({
+        where: expect.objectContaining({
+          id: "idOfUserWithChangedApprover",
+        }),
+        data: {
+          email: mockUser1.email,
+          team: mockUser1.team,
+          approver: !mockUser1.approver,
+          panelApprover: mockUser1.panelApprover,
+        },
+      })
+      expect(prisma.user.update).toBeCalledWith({
+        where: expect.objectContaining({
+          id: "idOfUserWithNoTeam",
+        }),
+        data: {
+          email: mockUser2.email,
+          team: null,
+          approver: mockUser2.approver,
+          panelApprover: mockUser2.panelApprover,
+        },
+      })
+    })
+
+    it("returns updated users", () => {
+      expect(response.json).toBeCalledWith(
+        expect.arrayContaining([
+          {
+            ...mockUser1,
+            approver: !mockUser1.approver,
+          },
+          {
+            ...mockUser2,
+            team: null,
+          },
+        ])
+      )
+    })
   })
 })

--- a/pagesTest/api/workflows/index.test.ts
+++ b/pagesTest/api/workflows/index.test.ts
@@ -1,14 +1,17 @@
-import {handler} from "../../../pages/api/workflows"
-import {NextApiResponse} from "next"
-import {mockWorkflow} from "../../../fixtures/workflows"
+import { handler } from "../../../pages/api/workflows"
+import { NextApiResponse } from "next"
+import { mockWorkflow } from "../../../fixtures/workflows"
 import prisma from "../../../lib/prisma"
-import {mockUser} from "../../../fixtures/users"
-import {mockResident} from "../../../fixtures/residents"
-import {mockForm} from "../../../fixtures/form"
-import {newWorkflowSchema} from "../../../lib/validators"
-import {getResidentById} from "../../../lib/residents"
-import {makeNextApiRequest, testApiHandlerUnsupportedMethods} from "../../../lib/auth/test-functions";
-import {mockSession} from "../../../fixtures/session";
+import { mockUser } from "../../../fixtures/users"
+import { mockResident } from "../../../fixtures/residents"
+import { mockForm } from "../../../fixtures/form"
+import { newWorkflowSchema } from "../../../lib/validators"
+import { getResidentById } from "../../../lib/residents"
+import {
+  makeNextApiRequest,
+  testApiHandlerUnsupportedMethods,
+} from "../../../lib/auth/test-functions"
+import { mockSession } from "../../../fixtures/session"
 
 jest.mock("../../../lib/prisma", () => ({
   workflow: {
@@ -23,8 +26,8 @@ jest.mock("../../../lib/residents")
 
 jest.mock("../../../lib/validators")
 
-describe('pages/api/workflows', () => {
-  testApiHandlerUnsupportedMethods(handler, ['GET', 'POST']);
+describe("pages/api/workflows", () => {
+  testApiHandlerUnsupportedMethods(handler, ["GET", "POST"])
 
   describe("when the HTTP method is GET", () => {
     let response
@@ -39,7 +42,7 @@ describe('pages/api/workflows', () => {
         formId: mockForm.id,
       })
       ;(newWorkflowSchema as jest.Mock).mockClear()
-      ;(newWorkflowSchema as jest.Mock).mockImplementation(() => ({validate}))
+      ;(newWorkflowSchema as jest.Mock).mockImplementation(() => ({ validate }))
 
       response = {
         status: jest.fn().mockImplementation(() => response),
@@ -48,11 +51,14 @@ describe('pages/api/workflows', () => {
     })
 
     it("correctly paginates the response", async () => {
-      await handler(makeNextApiRequest({
-        method: "GET",
-        query: {page: '2'},
-        session: mockSession,
-      }), response)
+      await handler(
+        makeNextApiRequest({
+          method: "GET",
+          query: { page: "2" },
+          session: mockSession,
+        }),
+        response
+      )
 
       expect(prisma.workflow.findMany).toBeCalledWith(
         expect.objectContaining({
@@ -64,16 +70,19 @@ describe('pages/api/workflows', () => {
     })
 
     it("doesn't return historic or discarded data by default", async () => {
-      await handler(makeNextApiRequest({
-        method: "GET",
-        query: {},
-        session: mockSession,
-      }), response)
+      await handler(
+        makeNextApiRequest({
+          method: "GET",
+          query: {},
+          session: mockSession,
+        }),
+        response
+      )
 
       expect(prisma.workflow.findMany).toBeCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
-            type: {in: ["Reassessment", "Review", "Assessment"]},
+            type: { in: ["Reassessment", "Review", "Assessment"] },
             discardedAt: null,
           }),
         })
@@ -81,13 +90,16 @@ describe('pages/api/workflows', () => {
     })
 
     it("can return historic data", async () => {
-      await handler(makeNextApiRequest({
-        method: "GET",
-        query: {
-          show_historic: "true",
-        },
-        session: mockSession,
-      }), response)
+      await handler(
+        makeNextApiRequest({
+          method: "GET",
+          query: {
+            show_historic: "true",
+          },
+          session: mockSession,
+        }),
+        response
+      )
 
       expect(prisma.workflow.findMany).toBeCalledWith(
         expect.objectContaining({
@@ -99,13 +111,16 @@ describe('pages/api/workflows', () => {
     })
 
     it("can return data for a specific social care id", async () => {
-      await handler(makeNextApiRequest({
-        method: "GET",
-        query: {
-          social_care_id: "foo",
-        },
-        session: mockSession,
-      }), response)
+      await handler(
+        makeNextApiRequest({
+          method: "GET",
+          query: {
+            social_care_id: "foo",
+          },
+          session: mockSession,
+        }),
+        response
+      )
 
       expect(prisma.workflow.findMany).toBeCalledWith(
         expect.objectContaining({
@@ -117,14 +132,17 @@ describe('pages/api/workflows', () => {
     })
 
     it("runs things touched by me", async () => {
-      await handler(makeNextApiRequest({
-        method: "GET",
-        query: {
-          quick_filter: "me",
-          touched_by_me: 'true',
-        },
-        session: mockSession,
-      }), response)
+      await handler(
+        makeNextApiRequest({
+          method: "GET",
+          query: {
+            quick_filter: "me",
+            touched_by_me: "true",
+          },
+          session: mockSession,
+        }),
+        response
+      )
 
       expect(prisma.workflow.findMany).toBeCalledWith(
         expect.objectContaining({
@@ -132,12 +150,12 @@ describe('pages/api/workflows', () => {
             AND: expect.arrayContaining([
               {
                 OR: [
-                  {assignedTo: mockUser.email},
-                  {createdBy: mockUser.email},
-                  {submittedBy: mockUser.email},
-                  {managerApprovedBy: mockUser.email},
-                  {panelApprovedBy: mockUser.email},
-                  {acknowledgedBy: mockUser.email},
+                  { assignedTo: mockUser.email },
+                  { createdBy: mockUser.email },
+                  { submittedBy: mockUser.email },
+                  { managerApprovedBy: mockUser.email },
+                  { panelApprovedBy: mockUser.email },
+                  { acknowledgedBy: mockUser.email },
                 ],
               },
             ]),
@@ -147,13 +165,16 @@ describe('pages/api/workflows', () => {
     })
 
     it("returns things assigned to me", async () => {
-      await handler(makeNextApiRequest({
-        method: "GET",
-        query: {
-          quick_filter: "me",
-        },
-        session: mockSession,
-      }), response)
+      await handler(
+        makeNextApiRequest({
+          method: "GET",
+          query: {
+            quick_filter: "me",
+          },
+          session: mockSession,
+        }),
+        response
+      )
 
       expect(prisma.workflow.findMany).toBeCalledWith(
         expect.objectContaining({
@@ -166,132 +187,112 @@ describe('pages/api/workflows', () => {
   })
 
   describe("when the HTTP method is POST", () => {
-    const body = {socialCareId: mockResident.mosaicId, formId: mockForm.id}
+    const body = { socialCareId: mockResident.mosaicId, formId: mockForm.id }
     let response
     let validate
 
-    beforeEach(() => {
-      ;(prisma.workflow.create as jest.Mock).mockClear()
-      ;(prisma.workflow.create as jest.Mock).mockResolvedValue(mockWorkflow)
+    describe("when the resident ID in the request exists", () => {
+      beforeAll(async () => {
+        ;(prisma.workflow.create as jest.Mock).mockResolvedValue(mockWorkflow)
 
-      validate = jest.fn().mockResolvedValue({
-        socialCareId: mockResident.mosaicId,
-        formId: mockForm.id,
+        validate = jest.fn().mockResolvedValue({
+          socialCareId: mockResident.mosaicId,
+          formId: mockForm.id,
+        })
+        ;(newWorkflowSchema as jest.Mock).mockImplementation(() => ({
+          validate,
+        }))
+
+        response = {
+          status: jest.fn().mockImplementation(() => response),
+          json: jest.fn(),
+        } as unknown as NextApiResponse
+
+        await handler(
+          makeNextApiRequest({
+            method: "POST",
+            body,
+            session: mockSession,
+          }),
+          response
+        )
       })
-      ;(newWorkflowSchema as jest.Mock).mockClear()
-      ;(newWorkflowSchema as jest.Mock).mockImplementation(() => ({validate}))
 
-      response = {
-        status: jest.fn().mockImplementation(() => response),
-        json: jest.fn(),
-      } as unknown as NextApiResponse
-    })
-
-    it("validates the request", async () => {
-      await handler(makeNextApiRequest({
-        method: "POST",
-        body,
-        session: mockSession,
-      }), response)
-
-      expect(validate).toBeCalledWith(body)
-    })
-
-    it("creates a new workflow with provided data", async () => {
-      await handler(makeNextApiRequest({
-        method: "POST",
-        body,
-        session: mockSession,
-      }), response)
-
-      expect(prisma.workflow.create).toBeCalledWith({
-        data: expect.objectContaining({
-          socialCareId: body.socialCareId,
-          formId: body.formId,
-        }),
+      it("validates the request", () => {
+        expect(validate).toBeCalledWith(body)
       })
-    })
 
-    it("creates a new workflow with it created by the current user", async () => {
-      await handler(makeNextApiRequest({
-        method: "POST",
-        body,
-        session: mockSession,
-      }), response)
-
-      expect(prisma.workflow.create).toBeCalledWith({
-        data: expect.objectContaining({
-          createdBy: mockUser.email,
-        }),
+      it("creates a new workflow with provided data", () => {
+        expect(prisma.workflow.create).toBeCalledWith({
+          data: expect.objectContaining({
+            socialCareId: body.socialCareId,
+            formId: body.formId,
+          }),
+        })
       })
-    })
 
-    it("creates a new workflow with it updated by the current user", async () => {
-      await handler(makeNextApiRequest({
-        method: "POST",
-        body,
-        session: mockSession,
-      }), response)
-
-      expect(prisma.workflow.create).toBeCalledWith({
-        data: expect.objectContaining({
-          updatedBy: mockUser.email,
-        }),
+      it("creates a new workflow with it created by the current user", () => {
+        expect(prisma.workflow.create).toBeCalledWith({
+          data: expect.objectContaining({
+            createdBy: mockUser.email,
+          }),
+        })
       })
-    })
 
-    it("creates a new workflow with it assigned to the current user", async () => {
-      await handler(makeNextApiRequest({
-        method: "POST",
-        body,
-        session: mockSession,
-      }), response)
+      it("creates a new workflow with it updated by the current user", () => {
+        expect(prisma.workflow.create).toBeCalledWith({
+          data: expect.objectContaining({
+            updatedBy: mockUser.email,
+          }),
+        })
+      })
 
-      expect(prisma.workflow.create).toBeCalledWith({
-        data: expect.objectContaining({
-          assignedTo: mockUser.email,
-        }),
+      it("creates a new workflow with it assigned to the current user", () => {
+        expect(prisma.workflow.create).toBeCalledWith({
+          data: expect.objectContaining({
+            assignedTo: mockUser.email,
+          }),
+        })
+      })
+
+      it("creates a new workflow with it team assigned to the current user's team", () => {
+        expect(prisma.workflow.create).toBeCalledWith({
+          data: expect.objectContaining({
+            teamAssignedTo: mockUser.team,
+          }),
+        })
+      })
+
+      it("returns 200 with the created workflow", () => {
+        expect(response.status).toBeCalledWith(201)
+        expect(response.json).toBeCalledWith(mockWorkflow)
       })
     })
 
-    it("creates a new workflow with it team assigned to the current user's team", async () => {
-      await handler(makeNextApiRequest({
-        method: "POST",
-        body,
-        session: mockSession,
-      }), response)
+    describe("when the resident ID in the request doesn't exist", () => {
+      beforeAll(async () => {
+        response = {
+          status: jest.fn().mockImplementation(() => response),
+          json: jest.fn(),
+        } as unknown as NextApiResponse
+        ;(getResidentById as jest.Mock).mockResolvedValue(null)
 
-      expect(prisma.workflow.create).toBeCalledWith({
-        data: expect.objectContaining({
-          teamAssignedTo: mockUser.team,
-        }),
+        await handler(
+          makeNextApiRequest({
+            method: "POST",
+            body,
+            session: mockSession,
+          }),
+          response
+        )
       })
-    })
 
-    it("returns 200 with the created workflow", async () => {
-      await handler(makeNextApiRequest({
-        method: "POST",
-        body,
-        session: mockSession,
-      }), response)
-
-      expect(response.status).toBeCalledWith(201)
-      expect(response.json).toBeCalledWith(mockWorkflow)
-    })
-
-    it("returns a not found error when the resident id does not exist", async () => {
-      ;(getResidentById as jest.Mock).mockResolvedValue(null)
-
-      await handler(makeNextApiRequest({
-        method: "POST",
-        body,
-        session: mockSession,
-      }), response)
-
-      expect(response.status).toBeCalledWith(404)
-      expect(response.status).not.toBeCalledWith(201)
-      expect(response.json).toBeCalledWith({error: "Resident does not exist."})
+      it("returns a not found error", () => {
+        expect(response.status).toBeCalledWith(404)
+        expect(response.json).toBeCalledWith({
+          error: "Resident does not exist.",
+        })
+      })
     })
   })
-
 })

--- a/pagesTest/api/workflows/index.test.ts
+++ b/pagesTest/api/workflows/index.test.ts
@@ -35,7 +35,10 @@ describe("pages/api/workflows", () => {
     let validate
 
     beforeEach(() => {
+      ;(prisma.workflow.count as jest.Mock).mockClear()
+      ;(prisma.workflow.count as jest.Mock).mockResolvedValue(20)
       ;(prisma.workflow.findMany as jest.Mock).mockClear()
+      ;(prisma.workflow.findMany as jest.Mock).mockResolvedValue([mockWorkflow])
       ;(prisma.workflow.create as jest.Mock).mockClear()
       ;(prisma.workflow.create as jest.Mock).mockResolvedValue(mockWorkflow)
 
@@ -312,6 +315,29 @@ describe("pages/api/workflows", () => {
         )
       })
     })
+
+    it("returns 200 with each workflow and its form and the count", async () => {
+      await handler(
+        makeNextApiRequest({
+          method: "GET",
+          query: {},
+          session: mockSession,
+        }),
+        response
+      )
+
+      expect(response.json).toBeCalledWith(
+        expect.objectContaining({
+          workflows: expect.arrayContaining([
+            expect.objectContaining({
+              id: mockWorkflow.id,
+              form: mockForm,
+            }),
+          ]),
+          count: 20,
+        })
+      )
+    })
   })
 
   describe("when the HTTP method is POST", () => {
@@ -391,7 +417,7 @@ describe("pages/api/workflows", () => {
         })
       })
 
-      it("returns 200 with the created workflow", () => {
+      it("returns 201 with the created workflow", () => {
         expect(response.status).toBeCalledWith(201)
         expect(response.json).toBeCalledWith(mockWorkflow)
       })

--- a/pagesTest/api/workflows/index.test.ts
+++ b/pagesTest/api/workflows/index.test.ts
@@ -241,6 +241,77 @@ describe("pages/api/workflows", () => {
         )
       })
     })
+
+    describe("and quick filter is set to 'my-team'", () => {
+      it("calls Prisma to find workflows team assigned to the current user's team", async () => {
+        await handler(
+          makeNextApiRequest({
+            method: "GET",
+            query: {
+              quick_filter: "my-team",
+            },
+            session: mockSession,
+          }),
+          response
+        )
+
+        expect(prisma.workflow.findMany).toBeCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              teamAssignedTo: mockUser.team,
+            }),
+          })
+        )
+      })
+    })
+
+    describe("and quick filter is set to 'another-team'", () => {
+      it("calls Prisma to find workflows team assigned to the team provided", async () => {
+        await handler(
+          makeNextApiRequest({
+            method: "GET",
+            query: {
+              quick_filter: "another-team",
+              team_assigned_to: "some-team-name",
+            },
+            session: mockSession,
+          }),
+          response
+        )
+
+        expect(prisma.workflow.findMany).toBeCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              teamAssignedTo: "some-team-name",
+            }),
+          })
+        )
+      })
+    })
+
+    describe("and quick filter is set to 'another-user'", () => {
+      it("calls Prisma to find workflows assigned to the user provided", async () => {
+        await handler(
+          makeNextApiRequest({
+            method: "GET",
+            query: {
+              quick_filter: "another-user",
+              assigned_to: "test@example.com",
+            },
+            session: mockSession,
+          }),
+          response
+        )
+
+        expect(prisma.workflow.findMany).toBeCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              assignedTo: "test@example.com",
+            }),
+          })
+        )
+      })
+    })
   })
 
   describe("when the HTTP method is POST", () => {

--- a/pagesTest/index.test.tsx
+++ b/pagesTest/index.test.tsx
@@ -1,22 +1,46 @@
 import { mockResident } from "../fixtures/residents"
 import { getResidentById } from "../lib/residents"
 import { getServerSideProps } from "../pages"
-import { getSession } from '../lib/auth/session';
+import { getSession } from "../lib/auth/session"
 import { mockForm } from "../fixtures/form"
-import {makeGetServerSidePropsContext, testGetServerSidePropsAuthRedirect} from "../lib/auth/test-functions";
-import {mockSession} from "../fixtures/session";
+import {
+  makeGetServerSidePropsContext,
+  testGetServerSidePropsAuthRedirect,
+} from "../lib/auth/test-functions"
+import {
+  mockSession,
+  mockSessionNotInPilot,
+  mockSessionPanelApprover,
+  mockSessionApprover,
+} from "../fixtures/session"
 
-jest.mock("../lib/residents");
-;(getResidentById as jest.Mock).mockResolvedValue(mockResident);
-jest.mock('../lib/auth/session');
+jest.mock("../lib/residents")
+;(getResidentById as jest.Mock).mockResolvedValue(mockResident)
+jest.mock("../lib/auth/session")
 
 describe("pages/index.getServerSideProps", () => {
-  testGetServerSidePropsAuthRedirect(
+  const context = makeGetServerSidePropsContext({})
+
+  testGetServerSidePropsAuthRedirect({
     getServerSideProps,
-    false,
-    false,
-    false,
-  );
+    tests: [
+      {
+        name: "user is not in pilot group",
+        session: mockSessionNotInPilot,
+        context,
+      },
+      {
+        name: "user is only an approver",
+        session: mockSessionApprover,
+        context,
+      },
+      {
+        name: "user is only a panel approver",
+        session: mockSessionPanelApprover,
+        context,
+      },
+    ],
+  })
 
   describe("when authenticated", () => {
     beforeAll(() => {
@@ -24,7 +48,7 @@ describe("pages/index.getServerSideProps", () => {
     })
 
     it("returns a list of workflows with forms as a prop", async () => {
-      const response = await getServerSideProps(makeGetServerSidePropsContext({}));
+      const response = await getServerSideProps(context)
 
       expect(response).toHaveProperty(
         "props",

--- a/pagesTest/residents/[socialCareId].test.tsx
+++ b/pagesTest/residents/[socialCareId].test.tsx
@@ -1,14 +1,23 @@
-import {GetServerSidePropsContext} from "next"
-import {mockForm} from "../../fixtures/form"
-import {mockResident} from "../../fixtures/residents"
-import {mockWorkflowWithExtras} from "../../fixtures/workflows"
-import {ParsedUrlQuery} from "querystring"
-import {getResidentById} from "../../lib/residents"
-import {getServerSideProps} from "../../pages/residents/[socialCareId]"
-import {getLoginUrl, getSession, UserNotLoggedIn} from "../../lib/auth/session";
-import {mockApprover} from "../../fixtures/users"
-import {mockSession} from "../../fixtures/session";
-import {makeGetServerSidePropsContext} from "../../lib/auth/test-functions";
+import { GetServerSidePropsContext } from "next"
+import { mockForm } from "../../fixtures/form"
+import { mockResident } from "../../fixtures/residents"
+import { mockWorkflowWithExtras } from "../../fixtures/workflows"
+import { ParsedUrlQuery } from "querystring"
+import { getResidentById } from "../../lib/residents"
+import ResidentWorkflowsPage, {
+  getServerSideProps,
+} from "../../pages/residents/[socialCareId]"
+import {
+  getLoginUrl,
+  getSession,
+  UserNotLoggedIn,
+} from "../../lib/auth/session"
+import { mockApprover } from "../../fixtures/users"
+import { mockSession } from "../../fixtures/session"
+import { makeGetServerSidePropsContext } from "../../lib/auth/test-functions"
+import Layout from "../../components/_Layout"
+import { useRouter } from "next/router"
+import { render, screen } from "@testing-library/react"
 
 jest.mock("../../lib/prisma", () => ({
   workflow: {
@@ -19,20 +28,31 @@ jest.mock("../../lib/prisma", () => ({
 jest.mock("../../lib/residents")
 ;(getResidentById as jest.Mock).mockResolvedValue(mockResident)
 
-jest.mock('../../lib/auth/session');
-(getSession as jest.Mock).mockResolvedValue(mockSession);
-(getLoginUrl as jest.Mock).mockImplementation((url = '') => `auth-server${url}`);
+jest.mock("../../lib/auth/session")
+;(getSession as jest.Mock).mockResolvedValue(mockSession)
+;(getLoginUrl as jest.Mock).mockImplementation(
+  (url = "") => `auth-server${url}`
+)
 
-describe("getServerSideProps", () => {
+jest.mock("next/router")
+;(useRouter as jest.Mock).mockReturnValue({
+  query: { socialCareId: mockResident.mosaicId },
+})
+
+jest.mock("../../components/_Layout")
+;(Layout as jest.Mock).mockImplementation(({ children }) => <>{children}</>)
+
+describe("pagesTest/residents/[socialCareId].getServerSideProps", () => {
   describe("when not authenticated", () => {
     beforeEach(() => {
-      ;(getSession as jest.Mock).mockRejectedValueOnce(new UserNotLoggedIn);
+      ;(getSession as jest.Mock).mockRejectedValueOnce(new UserNotLoggedIn())
     })
 
     it("returns a redirect to the auth server", async () => {
-      const response = await getServerSideProps(
-        {query: {}, req: {}} as GetServerSidePropsContext
-      );
+      const response = await getServerSideProps({
+        query: {},
+        req: {},
+      } as GetServerSidePropsContext)
 
       expect(response).toHaveProperty(
         "redirect",
@@ -43,14 +63,16 @@ describe("getServerSideProps", () => {
     })
 
     it("returns a redirect to the sign-in page that will redirect to another on login", async () => {
-      const response = await getServerSideProps(makeGetServerSidePropsContext({
-        resolvedUrl: "/some/random/page"
-      }));
+      const response = await getServerSideProps(
+        makeGetServerSidePropsContext({
+          resolvedUrl: "/some/random/page",
+        })
+      )
 
       expect(response).toHaveProperty(
         "redirect",
         expect.objectContaining({
-          destination: 'auth-server/some/random/page',
+          destination: "auth-server/some/random/page",
         })
       )
     })
@@ -58,13 +80,15 @@ describe("getServerSideProps", () => {
 
   describe("when authenticated", () => {
     beforeAll(() => {
-      ;(getSession as jest.Mock).mockResolvedValue({user: mockApprover})
+      ;(getSession as jest.Mock).mockResolvedValue({ user: mockApprover })
     })
 
     it("returns a list of workflows with forms as a prop", async () => {
-      const response = await getServerSideProps(makeGetServerSidePropsContext({
-        query: {socialCareId: mockResident.mosaicId} as ParsedUrlQuery,
-      }));
+      const response = await getServerSideProps(
+        makeGetServerSidePropsContext({
+          query: { socialCareId: mockResident.mosaicId } as ParsedUrlQuery,
+        })
+      )
 
       expect(response).toHaveProperty(
         "props",
@@ -80,9 +104,11 @@ describe("getServerSideProps", () => {
     })
 
     it("returns the resident as a prop", async () => {
-      const response = await getServerSideProps(makeGetServerSidePropsContext({
-        query: {socialCareId: mockResident.mosaicId} as ParsedUrlQuery,
-      }));
+      const response = await getServerSideProps(
+        makeGetServerSidePropsContext({
+          query: { socialCareId: mockResident.mosaicId } as ParsedUrlQuery,
+        })
+      )
 
       expect(response).toHaveProperty(
         "props",
@@ -90,6 +116,132 @@ describe("getServerSideProps", () => {
           resident: mockResident,
         })
       )
+    })
+  })
+})
+
+describe("<ResidentWorkflowsPage />", () => {
+  it("displays Workflows as the title of the page", () => {
+    render(<ResidentWorkflowsPage workflows={[]} resident={mockResident} />)
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Workflows" })
+    ).toBeVisible()
+  })
+
+  describe("when the resident exists", () => {
+    it("sets title to Workflows with resident name", () => {
+      const layout = jest.fn(({ children }) => <>{children}</>)
+
+      ;(Layout as jest.Mock).mockImplementation(layout)
+
+      render(
+        <ResidentWorkflowsPage
+          workflows={[]}
+          resident={{ ...mockResident, firstName: "Jane", lastName: "Doe" }}
+        />
+      )
+
+      expect(layout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Workflows | Jane Doe",
+        }),
+        expect.anything()
+      )
+    })
+
+    it("sets text for link in breadcrumbs to resident page as resident name", () => {
+      const layout = jest.fn(({ children }) => <>{children}</>)
+
+      ;(Layout as jest.Mock).mockImplementation(layout)
+
+      render(
+        <ResidentWorkflowsPage
+          workflows={[]}
+          resident={{ ...mockResident, firstName: "Jane", lastName: "Doe" }}
+        />
+      )
+
+      expect(layout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          breadcrumbs: expect.arrayContaining([
+            expect.objectContaining({
+              text: "Jane Doe",
+            }),
+          ]),
+        }),
+        expect.anything()
+      )
+    })
+  })
+
+  describe("when the resident doesn't exist", () => {
+    it("sets title to Workflows", () => {
+      const layout = jest.fn(({ children }) => <>{children}</>)
+
+      ;(Layout as jest.Mock).mockImplementation(layout)
+
+      render(<ResidentWorkflowsPage workflows={[]} resident={null} />)
+
+      expect(layout).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Workflows" }),
+        expect.anything()
+      )
+    })
+
+    it("sets text for link in breadcrumbs to resident page as social care ID", () => {
+      const layout = jest.fn(({ children }) => <>{children}</>)
+
+      ;(Layout as jest.Mock).mockImplementation(layout)
+
+      render(<ResidentWorkflowsPage workflows={[]} resident={null} />)
+
+      expect(layout).toHaveBeenCalledWith(
+        expect.objectContaining({
+          breadcrumbs: expect.arrayContaining([
+            expect.objectContaining({
+              text: "123",
+            }),
+          ]),
+        }),
+        expect.anything()
+      )
+    })
+  })
+
+  describe("when there are workflows", () => {
+    it("displays each workflow", () => {
+      render(
+        <ResidentWorkflowsPage
+          workflows={[
+            { ...mockWorkflowWithExtras, id: "123abc" },
+            { ...mockWorkflowWithExtras, id: "456def" },
+          ]}
+          resident={mockResident}
+        />
+      )
+
+      expect(screen.getAllByRole("link", { name: "View" })[0]).toBeVisible()
+      expect(screen.getAllByRole("link", { name: "View" })[1]).toBeVisible()
+    })
+
+    it("displays panel for unlinked reassessment", () => {
+      render(
+        <ResidentWorkflowsPage
+          workflows={[mockWorkflowWithExtras]}
+          resident={mockResident}
+        />
+      )
+
+      expect(screen.getByText("Trying to start a reassessment?")).toBeVisible()
+    })
+  })
+
+  describe("when there are no workflows", () => {
+    it("displays there are no workflows for the resident", () => {
+      render(<ResidentWorkflowsPage workflows={[]} resident={mockResident} />)
+
+      expect(screen.getByText("This resident has no workflows.")).toBeVisible()
     })
   })
 })

--- a/pagesTest/reviews/[id]/steps/[stepId].test.tsx
+++ b/pagesTest/reviews/[id]/steps/[stepId].test.tsx
@@ -121,6 +121,7 @@ describe("pages/reviews/[id]/steps/[stepId].getServerSideProps", () => {
         {
           name: "user is not in pilot group",
           session: mockSessionNotInPilot,
+          redirect: "/workflows/123abc",
           context,
         },
         {

--- a/pagesTest/workflows/[id]/finish.test.tsx
+++ b/pagesTest/workflows/[id]/finish.test.tsx
@@ -1,8 +1,13 @@
 import { mockForm } from "../../../fixtures/form"
 import { mockResident } from "../../../fixtures/residents"
-import { mockWorkflowWithExtras } from "../../../fixtures/workflows"
+import {
+  mockWorkflow,
+  mockWorkflowWithExtras,
+} from "../../../fixtures/workflows"
 import { getResidentById } from "../../../lib/residents"
-import { getServerSideProps } from "../../../pages/workflows/[id]/finish"
+import FinishWorkflowPage, {
+  getServerSideProps,
+} from "../../../pages/workflows/[id]/finish"
 import { getSession } from "../../../lib/auth/session"
 import {
   mockSession,
@@ -15,6 +20,14 @@ import {
   testGetServerSidePropsAuthRedirect,
 } from "../../../lib/auth/test-functions"
 import prisma from "../../../lib/prisma"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useRouter } from "next/router"
+import Layout from "../../../components/_Layout"
+import useResident from "../../../hooks/useResident"
+import useUsers from "../../../hooks/useUsers"
+import { mockApprover } from "../../../fixtures/users"
+import { screeningFormId } from "../../../config"
 
 jest.mock("../../../lib/prisma", () => ({
   workflow: {
@@ -27,6 +40,34 @@ jest.mock("../../../lib/residents")
 
 jest.mock("../../../lib/auth/session")
 ;(getSession as jest.Mock).mockResolvedValue(mockSession)
+
+jest.mock("next/router")
+;(useRouter as jest.Mock).mockReturnValue({
+  query: { id: mockWorkflow.id },
+  push: jest.fn(),
+})
+
+jest.mock("../../../components/_Layout")
+;(Layout as jest.Mock).mockImplementation(({ children }) => <>{children}</>)
+
+jest.mock("../../../hooks/useResident")
+;(useResident as jest.Mock).mockReturnValue({ data: mockResident })
+
+jest.mock("../../../hooks/useUsers")
+;(useUsers as jest.Mock).mockReturnValue({
+  data: [mockApprover],
+})
+
+global.fetch = jest.fn().mockResolvedValue({ json: jest.fn() })
+
+document.head.insertAdjacentHTML(
+  "afterbegin",
+  '<meta http-equiv="XSRF-TOKEN" content="test" />'
+)
+
+beforeEach(() => {
+  ;(fetch as jest.Mock).mockClear()
+})
 
 describe("page/workflows/[id]/finish.getServerSideProps", () => {
   const context = makeGetServerSidePropsContext({
@@ -60,13 +101,12 @@ describe("page/workflows/[id]/finish.getServerSideProps", () => {
   it("returns the workflow and form as props", async () => {
     const response = await getServerSideProps(context)
 
-    expect(response).toHaveProperty(
-      "props",
-      expect.objectContaining({
+    expect(response).toHaveProperty("props", {
+      workflow: expect.objectContaining({
         id: mockWorkflowWithExtras.id,
         form: mockForm,
-      })
-    )
+      }),
+    })
   })
 
   it("calls Prisma to find workflow and include next steps", async () => {
@@ -134,6 +174,110 @@ describe("page/workflows/[id]/finish.getServerSideProps", () => {
           destination: "/workflows/123abc",
         })
       )
+    })
+  })
+})
+
+describe("<FinishWorkflowPage />", () => {
+  it("displays the title", async () => {
+    await waitFor(() =>
+      render(
+        <FinishWorkflowPage
+          workflow={{ ...mockWorkflowWithExtras, form: mockForm }}
+        />
+      )
+    )
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Next steps and approval" })
+    ).toBeVisible()
+  })
+
+  describe("when a review date isn't chosen", () => {
+    it("displays an error", async () => {
+      await waitFor(() =>
+        render(
+          <FinishWorkflowPage
+            workflow={{ ...mockWorkflowWithExtras, form: mockForm }}
+          />
+        )
+      )
+
+      await waitFor(() => fireEvent.click(screen.getByText("Finish and send")))
+
+      expect(screen.getByText("You must provide a review date")).toBeVisible()
+    })
+  })
+
+  describe("when an approver isn't chosen", () => {
+    it("displays an error", async () => {
+      await waitFor(() =>
+        render(
+          <FinishWorkflowPage
+            workflow={{ ...mockWorkflowWithExtras, form: mockForm }}
+          />
+        )
+      )
+
+      await waitFor(() => fireEvent.click(screen.getByText("Finish and send")))
+
+      expect(screen.getByText("You must provide a user")).toBeVisible()
+    })
+  })
+
+  describe("when a screening assessment", () => {
+    it("doesn't display the review date question", async () => {
+      await waitFor(() =>
+        render(
+          <FinishWorkflowPage
+            workflow={{
+              ...mockWorkflowWithExtras,
+              form: { ...mockForm, id: screeningFormId },
+            }}
+          />
+        )
+      )
+
+      expect(
+        screen.queryByText("When should this be reviewed?", { exact: false })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("calls API to finish the workflow", async () => {
+    await waitFor(() => {
+      render(
+        <FinishWorkflowPage
+          workflow={{
+            ...mockWorkflowWithExtras,
+            nextSteps: [],
+            form: mockForm,
+          }}
+        />
+      )
+
+      fireEvent.click(screen.getByText("No review needed"))
+      userEvent.selectOptions(
+        screen.getByRole("combobox", {
+          name: /Who should approve this?/,
+        }),
+        [mockApprover.email]
+      )
+    })
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByText("Finish and send"))
+    })
+
+    expect(fetch).toHaveBeenCalledWith("/api/workflows/123abc/finish", {
+      body: JSON.stringify({
+        approverEmail: "firstname.surname@hackney.gov.uk",
+        reviewQuickDate: "no-review",
+        reviewBefore: "",
+        nextSteps: [],
+      }),
+      method: "POST",
+      headers: { "XSRF-TOKEN": "test" },
     })
   })
 })

--- a/pagesTest/workflows/[id]/index.test.tsx
+++ b/pagesTest/workflows/[id]/index.test.tsx
@@ -1,11 +1,19 @@
-import {mockForm} from "../../../fixtures/form"
-import {mockResident} from "../../../fixtures/residents"
-import {mockWorkflowWithExtras} from "../../../fixtures/workflows"
-import {getResidentById} from "../../../lib/residents"
-import {getServerSideProps} from "../../../pages/workflows/[id]"
-import {getSession} from "../../../lib/auth/session";
-import {mockSession} from "../../../fixtures/session";
-import {makeGetServerSidePropsContext, testGetServerSidePropsAuthRedirect} from "../../../lib/auth/test-functions";
+import { mockForm } from "../../../fixtures/form"
+import { mockResident } from "../../../fixtures/residents"
+import { mockWorkflowWithExtras } from "../../../fixtures/workflows"
+import { getResidentById } from "../../../lib/residents"
+import { getServerSideProps } from "../../../pages/workflows/[id]"
+import { getSession } from "../../../lib/auth/session"
+import {
+  mockSession,
+  mockSessionNotInPilot,
+  mockSessionPanelApprover,
+  mockSessionApprover,
+} from "../../../fixtures/session"
+import {
+  makeGetServerSidePropsContext,
+  testGetServerSidePropsAuthRedirect,
+} from "../../../lib/auth/test-functions"
 
 jest.mock("../../../lib/prisma", () => ({
   workflow: {
@@ -19,21 +27,36 @@ jest.mock("../../../lib/residents")
 jest.mock("../../../lib/auth/session")
 ;(getSession as jest.Mock).mockResolvedValue(mockSession)
 
-
 describe("pages/workflows/[id].getServerSideProps", () => {
-  testGetServerSidePropsAuthRedirect(
+  const context = makeGetServerSidePropsContext({
+    query: {
+      social_care_id: mockResident.mosaicId,
+    },
+  })
+
+  testGetServerSidePropsAuthRedirect({
     getServerSideProps,
-    false,
-    false,
-    false,
-  );
+    tests: [
+      {
+        name: "user is not in pilot group",
+        session: mockSessionNotInPilot,
+        context,
+      },
+      {
+        name: "user is only an approver",
+        session: mockSessionApprover,
+        context,
+      },
+      {
+        name: "user is only a panel approver",
+        session: mockSessionPanelApprover,
+        context,
+      },
+    ],
+  })
 
   it("returns the workflow and form as props", async () => {
-    const response = await getServerSideProps(makeGetServerSidePropsContext({
-      query: {
-        social_care_id: mockResident.mosaicId,
-      },
-    }));
+    const response = await getServerSideProps(context)
 
     expect(response).toHaveProperty(
       "props",

--- a/pagesTest/workflows/[id]/printable.test.tsx
+++ b/pagesTest/workflows/[id]/printable.test.tsx
@@ -1,11 +1,19 @@
-import {mockForm} from "../../../fixtures/form"
-import {mockResident} from "../../../fixtures/residents"
-import {mockWorkflowWithExtras} from "../../../fixtures/workflows"
-import {getResidentById} from "../../../lib/residents"
-import {getServerSideProps} from "../../../pages/workflows/[id]/printable"
-import {getSession} from "../../../lib/auth/session"
-import {mockSession} from "../../../fixtures/session";
-import {makeGetServerSidePropsContext, testGetServerSidePropsAuthRedirect} from "../../../lib/auth/test-functions";
+import { mockForm } from "../../../fixtures/form"
+import { mockResident } from "../../../fixtures/residents"
+import { mockWorkflowWithExtras } from "../../../fixtures/workflows"
+import { getResidentById } from "../../../lib/residents"
+import { getServerSideProps } from "../../../pages/workflows/[id]/printable"
+import { getSession } from "../../../lib/auth/session"
+import {
+  mockSession,
+  mockSessionNotInPilot,
+  mockSessionPanelApprover,
+  mockSessionApprover,
+} from "../../../fixtures/session"
+import {
+  makeGetServerSidePropsContext,
+  testGetServerSidePropsAuthRedirect,
+} from "../../../lib/auth/test-functions"
 
 jest.mock("../../../lib/prisma", () => ({
   workflow: {
@@ -20,17 +28,33 @@ jest.mock("../../../lib/auth/session")
 ;(getSession as jest.Mock).mockResolvedValue(mockSession)
 
 describe("getServerSideProps", () => {
-  testGetServerSidePropsAuthRedirect(
+  const context = makeGetServerSidePropsContext({
+    query: { social_care_id: mockResident.mosaicId },
+  })
+
+  testGetServerSidePropsAuthRedirect({
     getServerSideProps,
-    false,
-    false,
-    false,
-  );
+    tests: [
+      {
+        name: "user is not in pilot group",
+        session: mockSessionNotInPilot,
+        context,
+      },
+      {
+        name: "user is only an approver",
+        session: mockSessionApprover,
+        context,
+      },
+      {
+        name: "user is only a panel approver",
+        session: mockSessionPanelApprover,
+        context,
+      },
+    ],
+  })
 
   it("returns the workflow and form as props", async () => {
-    const response = await getServerSideProps(makeGetServerSidePropsContext({
-      query: {social_care_id: mockResident.mosaicId,}
-    }));
+    const response = await getServerSideProps(context)
 
     expect(response).toHaveProperty("props", {
       workflow: expect.objectContaining({

--- a/pagesTest/workflows/[id]/steps/[stepId].test.tsx
+++ b/pagesTest/workflows/[id]/steps/[stepId].test.tsx
@@ -142,7 +142,7 @@ describe("pages/workflows/[id]/steps/[stepId].getServerSideProps", () => {
         {
           name: "user is not in pilot group",
           session: mockSessionNotInPilot,
-          redirect: true,
+          redirect: "/workflows/123abc",
           context,
         },
         {
@@ -179,7 +179,7 @@ describe("pages/workflows/[id]/steps/[stepId].getServerSideProps", () => {
         {
           name: "user is not in pilot group",
           session: mockSessionNotInPilot,
-          redirect: true,
+          redirect: "/workflows/123abc",
           context,
         },
         {
@@ -217,7 +217,7 @@ describe("pages/workflows/[id]/steps/[stepId].getServerSideProps", () => {
         {
           name: "user is not in pilot group",
           session: mockSessionNotInPilot,
-          redirect: true,
+          redirect: "/workflows/123abc",
           context,
         },
         {


### PR DESCRIPTION
## Context

Before this PR, our test coverage looked like this:

![workflows-test-cov-20-dec](https://user-images.githubusercontent.com/42817036/146755248-8ae99c32-eb6c-4778-bf75-11681b33a2ce.png)

## Changes in this pull request

- Refactor the auth redirect test helper, `testGetServerSidePropsAuthRedirect` to enable moar flexibility.
- Add moar test coverage for:
  - `pages/api/workflows/index.ts`
  - `pages/workflows/[id]/steps/[stepId].tsx`
  - `pages/residents/[socialCareId].tsx`
  -  `pages/api/users.tsx`
  -  `pages/workflows/[id]/finish.tsx`
- Update step pages to redirect to /workflows/[id] if user is not in the pilot group.

Our test coverage atm i.e. coverage from 82.7% to 86.24%:

![image](https://user-images.githubusercontent.com/42817036/148524068-6aa01be8-2e0b-4522-a359-41255aeacbee.png)

