### PR TITLE
Feat/auto login on session expiry

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:3000",
   "chromeWebSecurity": false,
   "defaultCommandTimeout": 60000,
-  "retries": 2
+  "retries": 2,
+  "nodeVersion": "system"
 }

--- a/cypress/integration/authentication.js
+++ b/cypress/integration/authentication.js
@@ -1,14 +1,13 @@
 describe("visiting the app logged in", () => {
   it("can visit the website without being redirected", () => {
     cy.visitAsUser("/");
+    cy.location('hostname').should('eq', 'localhost')
   })
 })
 
 describe("visiting the app when not logged in", () => {
   it("redirected to the auth server", () => {
-    cy.visit("/", {
-      failOnStatusCode: false,
-    });
-    cy.location('host').should('eq', 'example.com')
+    cy.visit("/", {failOnStatusCode: false});
+    cy.location('hostname').should('eq', 'example.com')
   })
 })

--- a/lib/auth/SessionContext.tsx
+++ b/lib/auth/SessionContext.tsx
@@ -5,8 +5,8 @@ import {UserSession} from "./types";
 
 export const SessionContext = createContext<UserSession>(null);
 
-export const getFrontendLoginUrl = (): string =>
-  `${process.env.NEXT_PUBLIC_HACKNEY_AUTH_SERVER_URL}?redirect_uri=${window.location.toString()}`;
+export const getFrontendLoginUrl = (url: string = null): string =>
+  `${process.env.NEXT_PUBLIC_HACKNEY_AUTH_SERVER_URL}?redirect_uri=${url ? url : window.location.toString()}`;
 
 export const Session: FunctionComponent = ({children}) => {
   const router = useRouter();

--- a/lib/csrfToken.ts
+++ b/lib/csrfToken.ts
@@ -1,5 +1,6 @@
 import Tokens from 'csrf';
 import {NextApiRequest, NextApiResponse} from "next";
+import {authenticatedFetch} from "./fetch";
 
 export class CSRFValidationError extends Error {
   message = 'invalid csrf token provided';
@@ -48,7 +49,7 @@ export const {csrfFetch, init, middleware, token, tokenFromMeta, validate} = {
   tokenFromMeta: (): string =>
     (document.querySelector('meta[http-equiv=XSRF-TOKEN]') as HTMLMetaElement)?.content,
   csrfFetch: (url: string, init): Promise<Response> =>
-    fetch(url, {
+    authenticatedFetch(url, {
       ...init,
       headers: {
         ...(init.headers || {}),

--- a/lib/fetch.test.ts
+++ b/lib/fetch.test.ts
@@ -1,0 +1,111 @@
+import {describe, test} from "@jest/globals";
+import {authenticatedFetch} from "./fetch";
+import {waitFor} from "@testing-library/react";
+
+global.fetch = jest.fn();
+(global.fetch as jest.Mock).mockResolvedValue({status: 200} as Response);
+
+let windowClosed = false;
+const windowClose = jest.fn().mockImplementation(() => {console.log('closing window function', windowClosed); windowClosed = true;});
+
+window.open = jest.fn().mockImplementation(() => {
+  const url = new URL('http://auth-server/auth');
+
+  const location = Object.assign(url, {
+    ancestorOrigins: "",
+    assign: jest.fn(),
+    reload: jest.fn(),
+    replace: (newUrl) => {
+      location.host = (new URL(newUrl)).host;
+    }
+  });
+
+  const timeout = setTimeout(() => {
+    location.replace('http://localhost/auth/sign-in');
+    clearTimeout(timeout);
+  });
+
+  return {
+    closed: windowClosed,
+    location,
+  };
+});
+
+describe('lib/fetch', () => {
+  describe('when the user is authenticated', () => {
+    beforeAll(async () => {
+      (global.fetch as jest.Mock).mockClear();
+      (window.open as jest.Mock).mockClear();
+      (global.fetch as jest.Mock).mockResolvedValueOnce({status: 200} as Response);
+
+      await authenticatedFetch('test', {});
+    });
+
+    test('calls fetch with given url', () => {
+      expect(fetch).toHaveBeenCalledWith('test', {});
+    });
+
+    test('does not open a new tab', () => {
+      expect(window.open).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the user is not authenticated', () => {
+    describe('a single request', () => {
+      beforeAll(async () => {
+        (global.fetch as jest.Mock).mockClear();
+        (window.open as jest.Mock).mockClear();
+        (windowClose as jest.Mock).mockClear();
+        windowClosed = false;
+        (global.fetch as jest.Mock).mockResolvedValueOnce({status: 401} as Response);
+
+        setTimeout(() => {windowClosed = true}, 100);
+        await authenticatedFetch('test', {});
+      });
+
+      test('calls fetch with given url', () => {
+        expect(fetch).toHaveBeenNthCalledWith(1, 'test', {});
+      });
+
+      test('calls fetch again with given url', () => {
+        expect(fetch).toHaveBeenNthCalledWith(2, 'test', {});
+      });
+
+      test('opens a new tab with the login address', () => {
+        expect(window.open).toHaveBeenCalledWith(
+          'https://example.com/auth?redirect_uri=http://localhost/auth/sign-in',
+          'Login'
+        );
+      });
+    });
+    describe('multiple requests', () => {
+      beforeAll(async () => {
+        (global.fetch as jest.Mock).mockClear();
+        (window.open as jest.Mock).mockClear();
+        (windowClose as jest.Mock).mockClear();
+        windowClosed = false;
+        (global.fetch as jest.Mock).mockResolvedValueOnce({status: 401} as Response);
+        (global.fetch as jest.Mock).mockResolvedValueOnce({status: 401} as Response);
+
+        setTimeout(() => {windowClosed = true}, 200);
+        await waitFor(() => {
+          authenticatedFetch('test1', {});
+          authenticatedFetch('test2', {});
+        })
+      });
+
+      test('calls fetch with given url', () => {
+        expect(fetch).toHaveBeenCalledWith('test1', {});
+        expect(fetch).toHaveBeenCalledWith('test2', {});
+      });
+
+      test('only opens a single new tab with the login address', () => {
+        expect(window.open).toHaveBeenCalledWith(
+          'https://example.com/auth?redirect_uri=http://localhost/auth/sign-in',
+          'Login'
+        );
+        expect(window.open).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -1,0 +1,33 @@
+import {getFrontendLoginUrl} from "./auth/SessionContext";
+
+export const authenticatedFetch =
+  (resource: Request | string, init: RequestInit): Promise<Response> =>
+    fetch(resource, init)
+      .then((res) => new Promise(resolve => {
+        if (res.status !== 401) return resolve(res);
+
+        const windowName = 'loginOpenWindow';
+
+        if (!window[windowName]) {
+          window[windowName] = window.open(
+            getFrontendLoginUrl(`${window.location.protocol}//${window.location.host}/auth/sign-in`),
+            'Login',
+          );
+        }
+
+        const timer = setInterval(() => {
+          if (window[windowName] !== undefined) {
+            if (
+              window[windowName].closed ||
+              window[windowName]?.location.host === window.location.host
+            ) {
+              delete window[windowName]
+              clearInterval(timer);
+              fetch(resource, init).then(resolve);
+            }
+          } else {
+            clearInterval(timer);
+            fetch(resource, init).then(resolve);
+          }
+        }, 500);
+      }))

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,11 @@ module.exports = withSentryConfig({
       destination: "/",
       permanent: true,
     },
+    {
+      source: "/sign-in",
+      destination: "/",
+      permanent: true,
+    },
   ],
   webpack: (config, { isServer }) => {
     if (isServer) return config

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,12 @@
+import React from "react"
 import Head from "next/head"
-import { AppProps } from "next/app"
+import {AppProps} from "next/app"
 import "../styles/index.scss"
 import "../styles/helpers.scss"
-import { FlashMessageProvider } from "../contexts/flashMessages"
+import {FlashMessageProvider} from "../contexts/flashMessages"
 import {Session} from "../lib/auth/SessionContext";
+import {SWRConfig} from "swr"
+import {authenticatedFetch} from "../lib/fetch";
 
 if (typeof window !== "undefined") {
   document.body.className = document.body.className
@@ -11,23 +14,31 @@ if (typeof window !== "undefined") {
     : "js-enabled"
 }
 
-const App = ({ Component, pageProps }: AppProps): React.ReactElement => (
-  <Session>
-    <FlashMessageProvider>
-      <Head>
-        <title>Social care | Hackney Council</title>
-        <meta charSet="utf-8" />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1, viewport-fit=cover"
-        />
-        <meta name="theme-color" content="#0b0c0c" />
-        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-      </Head>
+const App = ({Component, pageProps}: AppProps): React.ReactElement => {
+  return (
+    <Session>
+      <SWRConfig value={{
+        fetcher: (resource, init) =>
+          authenticatedFetch(resource, init)
+            .then(res => (res as Response).json()),
+      }}>
+        <FlashMessageProvider>
+          <Head>
+            <title>Social care | Hackney Council</title>
+            <meta charSet="utf-8"/>
+            <meta
+              name="viewport"
+              content="width=device-width, initial-scale=1, viewport-fit=cover"
+            />
+            <meta name="theme-color" content="#0b0c0c"/>
+            <meta httpEquiv="X-UA-Compatible" content="IE=edge"/>
+          </Head>
 
-      <Component {...pageProps} />
-    </FlashMessageProvider>
-  </Session>
-)
+          <Component {...pageProps} />
+        </FlashMessageProvider>
+      </SWRConfig>
+    </Session>
+  )
+}
 
 export default App

--- a/pages/auth/sign-in.tsx
+++ b/pages/auth/sign-in.tsx
@@ -1,0 +1,29 @@
+import {GetServerSideProps} from "next"
+import Layout from "../../components/_Layout"
+import {protectRoute} from "../../lib/protectRoute";
+
+const SignInPage = (): React.ReactElement => {
+  return (
+    <Layout announcementArea={(
+      <section className="lbh-announcement lbh-announcement--site">
+        <div className="lbh-container">
+          <h3 className="lbh-announcement__title">You can close this window</h3>
+          <div className="lbh-announcement__content">
+            <p>
+              You were signed out, but we have signed you in again.
+            </p>
+            <p>
+              You may now close this window or tab to return to your work.
+            </p>
+          </div>
+        </div>
+      </section>
+    )}>
+    </Layout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps =
+  protectRoute(async () => ({props: {}}));
+
+export default SignInPage;


### PR DESCRIPTION
What?

If a fetch request gets a 401 status code response, open a new tab and allow the user to re-auth. Once authenticated, retry the original request, returning the result.

Why?

When a user requests a page we can re-auth them without the user noticing (auth redirects). However if the request is a fetch request we can't do this without moving the user to another page, which would mean the user loses what they have been working on. This solution allows the user to continue working after closing the newly opened tab.