### PR TITLE
Remove second line hint: `This doesn't include reassessments` from workflow creation form

### DIFF
--- a/pages/workflows/new.tsx
+++ b/pages/workflows/new.tsx
@@ -161,7 +161,6 @@ const NewWorkflowPage = ({ resident, forms }: Props): React.ReactElement => {
                   <SelectField
                     name="workflowId"
                     label="Is this linked to any of this resident's earlier assessments?"
-                    hint="This doesn't include reassessments"
                     touched={touched}
                     errors={errors}
                     choices={workflowChoices}


### PR DESCRIPTION
It was suggested that we remove the second line hint text on the linking question on the workflow creation page, so it just reads 'is this linked to any of a resident's earlier assessments?' since reassessments are linked automatically to the one before.

Before:
<img width="567" alt="Screenshot 2022-02-01 at 11 06 51" src="https://user-images.githubusercontent.com/32823756/151961082-817a7f68-96c5-4127-b83d-c5996a1d6959.png">

After:
<img width="647" alt="Screenshot 2022-02-01 at 11 06 33" src="https://user-images.githubusercontent.com/32823756/151961104-6e6a4ada-1cf2-4153-a4d4-ff31896ca7ec.png">

N.B I haven't edited the styling, I think this may just be my local dev setup.