### PR TITLE
Fixed some errant spaces in contentful and ran the import.

### DIFF
--- a/config/answerFilters/answerFilters.json
+++ b/config/answerFilters/answerFilters.json
@@ -61,7 +61,7 @@
       ],
       "Carer's home and living needs": [],
       "Carer's support plan": [
-        "How will each of the carer's needs be met? "
+        "How will each of the carer's needs be met?"
       ],
       "Carer's care and relationship needs": [],
       "Carer's work and recreation needs": [],
@@ -83,6 +83,7 @@
       "Telecare": [],
       "Needs identified": [],
       "Immediate Services": [
+        "First carer - Weekly timetable",
         "Second carer - Weekly timetable",
         "Total number of weekly hours"
       ],
@@ -177,7 +178,7 @@
       ],
       "Carer's home and living needs": [],
       "Carer's support plan": [
-        "How will each of the carer's needs be met? "
+        "How will each of the carer's needs be met?"
       ],
       "Carer's care and relationship needs": [],
       "Carer's work and recreation needs": [],
@@ -212,7 +213,7 @@
         "What are the risks identified?",
         "Desired outcomes for immediate service",
         "Will this person need the assistance of two carers?",
-        "First carer - Weekly timetable ",
+        "First carer - Weekly timetable",
         "Second carer - Weekly timetable",
         "Total number of weekly hours",
         "Spending plan start date",

--- a/jobs/import-answer-filter-contentful.js
+++ b/jobs/import-answer-filter-contentful.js
@@ -15,6 +15,8 @@ const generateAnswers = (steps, linkedEntries, team) =>
       )
       .map(
         linkedEntry => linkedEntry?.fields.id || linkedEntry?.fields.question
+      ).map(entry =>
+        entry.trim()
       )
 
     acc[step.fields.name] = fieldsToInclude || []


### PR DESCRIPTION
For some reason, immediate services > first carer timetable would not lose the trailing space even though it's no longer in contentful, so I put a trim in the import job which will do the same job and hopefully future-proof any other errant spaces I might have missed