### PR TITLE
Add teamSubmittedBy column to Workflow table

### DIFF
--- a/fixtures/workflows.ts
+++ b/fixtures/workflows.ts
@@ -90,6 +90,7 @@ export const mockSubmittedWorkflowWithExtras: MockWorkflowWithExtras = {
   ...mockWorkflowWithExtras,
   submittedAt: new Date(),
   submittedBy: mockUser.email,
+  teamSubmittedBy: mockUser.team,
   managerApprovedAt: null,
   managerApprovedBy: null,
   managerApprover: null,

--- a/fixtures/workflows.ts
+++ b/fixtures/workflows.ts
@@ -26,6 +26,7 @@ export const mockWorkflow: Workflow = {
   reviewBefore: null,
   submittedAt: null,
   submittedBy: null,
+  teamSubmittedBy: null,
   managerApprovedAt: null,
   managerApprovedBy: null,
   acknowledgedAt: null,

--- a/pages/api/teams/[id]/kpis.ts
+++ b/pages/api/teams/[id]/kpis.ts
@@ -60,7 +60,7 @@ export const handler = async (
       ] = await Promise.all([
         await prisma.workflow.count({
           where: {
-            teamAssignedTo: team,
+            teamSubmittedBy: team,
             createdAt: {
               gte: thirtyDaysAgo,
             },
@@ -68,7 +68,7 @@ export const handler = async (
         }),
         await prisma.workflow.count({
           where: {
-            teamAssignedTo: team,
+            teamSubmittedBy: team,
             submittedAt: {
               gte: thirtyDaysAgo,
             },
@@ -76,7 +76,7 @@ export const handler = async (
         }),
         await prisma.workflow.count({
           where: {
-            teamAssignedTo: team,
+            teamSubmittedBy: team,
             OR: [
               {
                 panelApprovedAt: {
@@ -96,13 +96,13 @@ export const handler = async (
         await prisma.$queryRaw`SELECT TO_CHAR(AVG("managerApprovedAt" - "createdAt"), 'DD') AS "meanTimeToApproval"
                                FROM "Workflow"
                                WHERE "managerApprovedAt" IS NOT null
-                                 AND "teamAssignedTo" = ${team}`,
+                                 AND "teamSubmittedBy" = ${team}`,
 
         // prev 30 days
 
         await prisma.workflow.count({
           where: {
-            teamAssignedTo: team,
+            teamSubmittedBy: team,
             createdAt: {
               gte: sixtyDaysAgo,
               lte: thirtyDaysAgo,
@@ -111,7 +111,7 @@ export const handler = async (
         }),
         await prisma.workflow.count({
           where: {
-            teamAssignedTo: team,
+            teamSubmittedBy: team,
             submittedAt: {
               gte: sixtyDaysAgo,
               lte: thirtyDaysAgo,
@@ -120,7 +120,7 @@ export const handler = async (
         }),
         await prisma.workflow.count({
           where: {
-            teamAssignedTo: team,
+            teamSubmittedBy: team,
             OR: [
               {
                 panelApprovedAt: {

--- a/pages/api/workflows/[id]/finish.ts
+++ b/pages/api/workflows/[id]/finish.ts
@@ -1,11 +1,11 @@
-import {NextApiRequest, NextApiResponse} from "next"
+import { NextApiRequest, NextApiResponse } from "next"
 import { apiHandler } from "../../../../lib/apiHelpers"
 import { triggerNextSteps } from "../../../../lib/nextSteps"
 import { notifyApprover } from "../../../../lib/notify"
 import { middleware as csrfMiddleware } from "../../../../lib/csrfToken"
 import prisma from "../../../../lib/prisma"
 
-const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query
 
   const values = JSON.parse(req.body)
@@ -24,6 +24,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     data: {
       submittedAt: new Date(),
       submittedBy: req['user']?.email,
+      teamSubmittedBy: req['user']?.team,
       reviewBefore: new Date(values.reviewBefore) || null,
       assignedTo: values.approverEmail,
       nextSteps: {

--- a/pages/api/workflows/[id]/finish.ts
+++ b/pages/api/workflows/[id]/finish.ts
@@ -5,7 +5,7 @@ import { notifyApprover } from "../../../../lib/notify"
 import { middleware as csrfMiddleware } from "../../../../lib/csrfToken"
 import prisma from "../../../../lib/prisma"
 
-export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+export const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   const { id } = req.query
 
   const values = JSON.parse(req.body)

--- a/pagesTest/api/teams/[id]/kpis.test.ts
+++ b/pagesTest/api/teams/[id]/kpis.test.ts
@@ -64,7 +64,7 @@ describe("/api/teams/[id]/kpis", () => {
     test('checks for workflows started in the last thirty days', () => {
       expect(prisma.workflow.count).toHaveBeenCalledWith({
         where: {
-          teamAssignedTo: 'Access',
+          teamSubmittedBy: 'Access',
           createdAt: {
             gte: THIRTY_DAYS_AGO,
           },
@@ -75,7 +75,7 @@ describe("/api/teams/[id]/kpis", () => {
     test('checks for workflows submitted in the last thirty days', () => {
       expect(prisma.workflow.count).toHaveBeenCalledWith({
         where: {
-          teamAssignedTo: 'Access',
+          teamSubmittedBy: 'Access',
           submittedAt: {
             gte: THIRTY_DAYS_AGO,
           },
@@ -86,7 +86,7 @@ describe("/api/teams/[id]/kpis", () => {
     test('checks for workflows manager or panel approved in the last thirty days', () => {
       expect(prisma.workflow.count).toHaveBeenCalledWith({
         where: {
-          teamAssignedTo: 'Access',
+          teamSubmittedBy: 'Access',
           OR: [
             {
               panelApprovedAt: {
@@ -110,7 +110,7 @@ describe("/api/teams/[id]/kpis", () => {
           expect.stringContaining(`SELECT TO_CHAR(AVG("managerApprovedAt" - "createdAt"), 'DD') AS "meanTimeToApproval"`),
           expect.stringContaining(`FROM "Workflow"`),
           expect.stringContaining(`WHERE "managerApprovedAt" IS NOT null`),
-          expect.stringContaining(`AND "teamAssignedTo" = `),
+          expect.stringContaining(`AND "teamSubmittedBy" = `),
         ]),
         "Access"
       );
@@ -119,7 +119,7 @@ describe("/api/teams/[id]/kpis", () => {
     test('checks for workflows started between sixty and thirty days ago', () => {
       expect(prisma.workflow.count).toHaveBeenCalledWith({
         where: {
-          teamAssignedTo: 'Access',
+          teamSubmittedBy: 'Access',
           createdAt: {
             gte: SIXTY_DAYS_AGO,
             lte: THIRTY_DAYS_AGO,
@@ -131,7 +131,7 @@ describe("/api/teams/[id]/kpis", () => {
     test('checks for workflows submitted between sixty and thirty days ago', () => {
       expect(prisma.workflow.count).toHaveBeenCalledWith({
         where: {
-          teamAssignedTo: 'Access',
+          teamSubmittedBy: 'Access',
           submittedAt: {
             gte: SIXTY_DAYS_AGO,
             lte: THIRTY_DAYS_AGO,
@@ -143,7 +143,7 @@ describe("/api/teams/[id]/kpis", () => {
     test('checks for workflows manager or panel approved between sixty and thirty days ago', () => {
       expect(prisma.workflow.count).toHaveBeenCalledWith({
         where: {
-          teamAssignedTo: 'Access',
+          teamSubmittedBy: 'Access',
           OR: [
             {
               panelApprovedAt: {

--- a/pagesTest/api/workflows/[id]/finish.test.ts
+++ b/pagesTest/api/workflows/[id]/finish.test.ts
@@ -1,0 +1,129 @@
+import prisma from "../../../../lib/prisma"
+import {mockManagerApprovedWorkflowWithExtras, mockSubmittedWorkflowWithExtras} from "../../../../fixtures/workflows";
+import {mockSession} from "../../../../fixtures/session";
+import {mockApprover, mockUser} from "../../../../fixtures/users";
+import {NextApiResponse} from "next";
+import {handler} from "../../../../pages/api/workflows/[id]/finish";
+import {makeNextApiRequest} from "../../../../lib/auth/test-functions";
+import {notifyApprover} from "../../../../lib/notify";
+import {triggerNextSteps} from "../../../../lib/nextSteps";
+
+jest.mock("../../../../lib/nextSteps")
+jest.mock("../../../../lib/notify")
+
+jest.mock("../../../../lib/prisma", () => ({
+  nextStep: {
+    deleteMany: jest.fn()
+  },
+  workflow: {
+    update: jest.fn(),
+  }
+}))
+
+const mockDateNow = new Date()
+jest
+  .spyOn(global, "Date")
+  .mockImplementation(() => mockDateNow as unknown as string)
+
+const response = {
+  status: jest.fn().mockImplementation(() => response),
+  json: jest.fn(),
+} as unknown as NextApiResponse
+
+describe('pages/api/workflows/[id]/finish', () => {
+  beforeAll(async () => {
+    ;(prisma.workflow.update as jest.Mock).mockResolvedValue(mockSubmittedWorkflowWithExtras)
+
+    await handler(makeNextApiRequest({
+        method: 'POST',
+        query: {id: mockSubmittedWorkflowWithExtras.id},
+        session: mockSession,
+        body: {
+          approverEmail: mockApprover.email,
+          nextSteps: mockSubmittedWorkflowWithExtras.nextSteps,
+        },
+      }),
+      response);
+  })
+
+  const expectedNextSteps = mockSubmittedWorkflowWithExtras.nextSteps.map(nextStep => (
+    {
+      nextStepOptionId: nextStep.nextStepOptionId,
+      altSocialCareId: nextStep.altSocialCareId,
+      note: nextStep.note,
+    }
+  ))
+
+  it("should delete next steps to prevent duplicates", () => {
+    expect(prisma.nextStep.deleteMany).toHaveBeenCalledWith(
+      {where: {workflowId: mockSubmittedWorkflowWithExtras.id}}
+    )
+  })
+
+  it("updates the workflow with with the correct submission information", () => {
+    expect(prisma.workflow.update).toBeCalledWith(
+      expect.objectContaining({
+        where: {id: mockSubmittedWorkflowWithExtras.id},
+        data: expect.objectContaining({
+          submittedAt: mockDateNow,
+          submittedBy: mockUser.email,
+          teamSubmittedBy: mockUser.team,
+          reviewBefore: mockDateNow,
+          assignedTo: mockApprover.email,
+          nextSteps: {
+            createMany: {
+              data: expect.arrayContaining(expectedNextSteps)
+            }
+          },
+          revisions: {
+            create: {
+              answers: {},
+              createdBy: mockUser.email,
+              action: 'Submitted',
+            }
+          },
+        })
+      }))
+  })
+
+  it("includes the next steps of the workflow that aren't triggered", () => {
+    expect(prisma.workflow.update).toBeCalledWith(
+      expect.objectContaining({
+        where: {id: mockSubmittedWorkflowWithExtras.id},
+        include: expect.objectContaining({
+          nextSteps: {
+            where: {
+              triggeredAt: null,
+            }
+          }
+        })
+      }))
+  })
+
+  it("includes the creator of workflow", () => {
+    expect(prisma.workflow.update).toBeCalledWith(
+      expect.objectContaining({
+        where: {id: mockManagerApprovedWorkflowWithExtras.id},
+        include: expect.objectContaining({
+          creator: true,
+        }),
+      })
+    )
+  })
+
+  it("sends an approval email to assignee of workflow", () => {
+    expect(notifyApprover).toBeCalledWith(
+      mockSubmittedWorkflowWithExtras,
+      mockApprover.email,
+      process.env.APP_URL
+    )
+  });
+
+  it("triggers next steps for the workflow", () => {
+    expect(triggerNextSteps).toHaveBeenCalledWith(mockSubmittedWorkflowWithExtras)
+  })
+
+  it("returns the updated workflow", () => {
+    expect(response.json).toHaveBeenCalledWith(mockSubmittedWorkflowWithExtras)
+  })
+})

--- a/prisma/migrations/20220207170950_add_team_submitted_by_column_to_workflows/migration.sql
+++ b/prisma/migrations/20220207170950_add_team_submitted_by_column_to_workflows/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Workflow" ADD COLUMN     "teamSubmittedBy" "Team";
+
+UPDATE "Workflow"
+SET "teamSubmittedBy" = (SELECT U.team from "User" U WHERE U.email = "submittedBy")
+WHERE type != 'Historic';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Workflow {
   submittedAt        DateTime?
   submittedBy        String?
   submitter          User?        @relation(name: "submitter", fields: [submittedBy], references: [email])
+  teamSubmittedBy    Team?
   // 3. approval
   managerApprovedAt  DateTime?
   managerApprovedBy  String?


### PR DESCRIPTION
### What
This PR adds a new column to the Workflow table which captures the team of the user who finished the workflow
### Why
This is to let the team KPI's show the correct metrics of finished workflows for each team