### PR TITLE
feat: only patch changed users

### DIFF
--- a/components/UserSelect.tsx
+++ b/components/UserSelect.tsx
@@ -30,8 +30,6 @@ const UserOptions = ({
   if (usersByTeam)
     usersByTeam = Object.fromEntries(Object.entries(usersByTeam).sort())
 
-  console.log(usersByTeam)
-
   if (users && usersByTeam)
     return (
       <>

--- a/pages/users.tsx
+++ b/pages/users.tsx
@@ -69,10 +69,15 @@ const UsersPage = ({users}: { users: Array<User> }): React.ReactElement => {
   }, {})
 
   const handleSubmit = async (values: EditableUserValues, {setStatus}) => {
+    const changedUsers = Object.fromEntries(
+      Object.entries(values)
+        .filter(([index, value]) => JSON.stringify(value) !== JSON.stringify(initialValues[index]))
+    );
+
     try {
       const res = await csrfFetch(`/api/users`, {
         method: "PATCH",
-        body: JSON.stringify(values),
+        body: JSON.stringify(changedUsers),
       })
       if (!res.ok) throw res.status
     } catch (e) {

--- a/pagesTest/users.test.tsx
+++ b/pagesTest/users.test.tsx
@@ -72,6 +72,28 @@ describe('<UsersPage />', () => {
       })
     });
   });
+
+  describe('setting a user as an approver', () => {
+    beforeEach(async () => {
+      const {getAllByRoleWithinRow} = getRowContext('Bob')
+      await waitFor(() => {
+        fireEvent.click(getAllByRoleWithinRow('checkbox')[0])
+      });
+    });
+    test('only updates the changed user', () => {
+      expect(csrfFetch).toHaveBeenCalledWith("/api/users", {
+        body: JSON.stringify({
+          abc123: {
+            email: "test@example.com",
+            team: "Access",
+            approver: true,
+            panelApprover: false,
+          }
+        }),
+        method: "PATCH"
+      })
+    });
+  });
 });
 
 describe("pages/users.getServerSideProps", () => {

--- a/pagesTest/users.test.tsx
+++ b/pagesTest/users.test.tsx
@@ -51,6 +51,27 @@ describe('<UsersPage />', () => {
     );
   });
 
+  describe('updating a users team', () => {
+    beforeEach(async () => {
+      const {getByRoleWithinRow} = getRowContext('Bob')
+      await waitFor(() => {
+        fireEvent.change(getByRoleWithinRow('combobox'), {target: {value: 'DirectPayments'}})
+      });
+    });
+    test('only updates the changed user', () => {
+      expect(csrfFetch).toHaveBeenCalledWith("/api/users", {
+        body: JSON.stringify({
+          abc123: {
+            email: "test@example.com",
+            team: "DirectPayments",
+            approver: false,
+            panelApprover: false,
+          }
+        }),
+        method: "PATCH"
+      })
+    });
+  });
 });
 
 describe("pages/users.getServerSideProps", () => {

--- a/pagesTest/users.test.tsx
+++ b/pagesTest/users.test.tsx
@@ -94,6 +94,28 @@ describe('<UsersPage />', () => {
       })
     });
   });
+
+  describe('setting a user as a QAM authoriser', () => {
+    beforeEach(async () => {
+      const {getAllByRoleWithinRow} = getRowContext('Bob')
+      await waitFor(() => {
+        fireEvent.click(getAllByRoleWithinRow('checkbox')[1])
+      });
+    });
+    test('only updates the changed user', () => {
+      expect(csrfFetch).toHaveBeenCalledWith("/api/users", {
+        body: JSON.stringify({
+          abc123: {
+            email: "test@example.com",
+            team: "Access",
+            approver: false,
+            panelApprover: true,
+          }
+        }),
+        method: "PATCH"
+      })
+    });
+  });
 });
 
 describe("pages/users.getServerSideProps", () => {


### PR DESCRIPTION
## What?

Change user patch request to only send the users that have changed from the initial values.

## Why?

Currently the whole list of users is sent, this results in every user being included in the audit logs as having been updated. As we expand, this will get worse.

## How?

Filter the users by comparing json strings of the original and updated values, allowing only those that changed to be sent in the request.