### PR TITLE
fix: reduce the noise in the user audit table

### DIFF
--- a/prisma/migrations/20220215103944_change_audit_table_to_not_log_some_changed/migration.sql
+++ b/prisma/migrations/20220215103944_change_audit_table_to_not_log_some_changed/migration.sql
@@ -1,0 +1,21 @@
+-- Replace the trigger for user audit with one that will ignore lastSeenAt and updatedAt
+CREATE OR REPLACE FUNCTION User_Audit_Trigger() RETURNS TRIGGER AS
+$User_Audit$
+BEGIN
+    IF (TG_OP = 'DELETE') THEN
+        INSERT INTO "User_Audit" (operation, id, before, after)
+        VALUES ('DELETE', old.id, TO_JSONB(old), '"null"');
+    ELSIF (TG_OP = 'INSERT') THEN
+        INSERT INTO "User_Audit" (operation, id, before, after)
+        VALUES ('INSERT', new.id, '"null"', TO_JSONB(new));
+    ELSIF (TG_OP = 'UPDATE') THEN
+        old."lastSeenAt" = new."lastSeenAt";
+        old."updatedAt" = new."updatedAt";
+        IF OLD IS DISTINCT FROM NEW THEN
+            INSERT INTO "User_Audit" (operation, id, before, after)
+            VALUES ('UPDATE', old.id, TO_JSONB(old), TO_JSONB(new));
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$User_Audit$ LANGUAGE plpgsql;


### PR DESCRIPTION
## What?

Ignore update queries that alter anything apart from the `lastSeenAt` or `updatedAt` columns for a user record.

## Why?

At the moment all updates to users are logged in the user audit table. This includes updates on every page load that change the timestamp of when the user was last seen in the system. The current table in prod has generated over 12K logs for the last 18 hour period.

## How?

Replace the current `User_Audit_Trigger` procedure with one that ignores updates to `lastSeenAt` and `updatedAt`.