### PR TITLE
Automatically deploy changes to Next Steps & Answer Filters

### DIFF
--- a/.github/workflows/upload-content-files.yml
+++ b/.github/workflows/upload-content-files.yml
@@ -9,10 +9,9 @@ on:
     types:
       - forms_changed
       - next_steps_changed
-      # - answer_filter_changed #( Not sure if we can separate updating a question to include an answer filter from saving changes on the entire form )
 
 jobs:
-  commit-new-forms:
+  commit-updated-content:
     runs-on: ubuntu-latest
     concurrency: content-commit
     steps:
@@ -27,13 +26,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Update form config
+      - name: Update form and/or filter config
+        if: github.event.event_type == 'forms_changed'
         env:
           CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
-        run: npm run import:contentful:forms
+        run: |
+          npm run import:contentful:forms
+          npm run import:contentful:answer-filters
 
-      - name: Commit changes
+      - name: Commit form changes
+        if: github.event.event_type == 'forms_changed'
         continue-on-error: true
         run: |
           git config user.name "GitHub Actions Bot"
@@ -42,28 +45,8 @@ jobs:
           git commit -m "Updated form data from Contentful"
           git push origin main
 
-  commit-new-answer-filters:
-    runs-on: ubuntu-latest
-    concurrency: content-commit
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14
-
-      - run: git pull -r
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Update answer filter config
-        env:
-          CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
-          CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
-        run: npm run import:contentful:answer-filters
-
-      - name: Commit changes
+      - name: Commit answer filter changes
+        if: github.event.event_type == 'forms_changed'
         continue-on-error: true
         run: |
           git config user.name "GitHub Actions Bot"
@@ -72,28 +55,15 @@ jobs:
           git commit -m "Updated answer filters from Contentful"
           git push origin main
 
-  commit-new-next-steps:
-    runs-on: ubuntu-latest
-    concurrency: content-commit
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14
-
-      - run: git pull -r
-
-      - name: Install dependencies
-        run: npm ci
-
       - name: Update next step config
+        if: github.event.event_type == 'next_steps_changed'
         env:
           CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
         run: npm run import:contentful:next-steps
 
-      - name: Commit changes
+      - name: Commit next step changes
+        if: github.event.event_type == 'next_steps_changed'
         continue-on-error: true
         run: |
           git config user.name "GitHub Actions Bot"
@@ -107,9 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: content-staging
     needs:
-      - commit-new-forms
-      - commit-new-answer-filters
-      - commit-new-next-steps
+      - commit-updated-content
     environment:
       name: Content - Staging
     env:
@@ -127,7 +95,6 @@ jobs:
 
   push-forms-to-production:
     name: 🚀 Push forms to S3 (Production)
-    if: github.event.event_type == 'forms_changed' #Can we access webhook data later down the pipeline?
     runs-on: ubuntu-latest
     concurrency: content-update-forms-production
     needs:
@@ -147,13 +114,12 @@ jobs:
 
   push-answer-filters-to-production:
     name: 🚀 Push answer filters to S3 (Production)
-    if: github.event.event_type == 'forms_changed' #Can we access webhook data later down the pipeline?
     runs-on: ubuntu-latest
-    concurrency: content-update-filters-production
+    concurrency: content-update-answer-filters-production
     needs:
       - push-content-to-staging
     environment:
-      name: Content Update Filters - Production
+      name: Content Update Answer Filters - Production
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
@@ -167,7 +133,6 @@ jobs:
 
   push-next-steps-to-production:
     name: 🚀 Push next step options to S3 (Production)
-    if: github.event.event_type == 'next_steps_changed' #Can we access webhook data later down the pipeline?
     runs-on: ubuntu-latest
     concurrency: content-update-next-steps-production
     needs:

--- a/.github/workflows/upload-content-files.yml
+++ b/.github/workflows/upload-content-files.yml
@@ -8,6 +8,8 @@ on:
   repository_dispatch:
     types:
       - forms_changed
+      - next_steps_changed
+      # - answer_filter_changed #( Not sure if we can separate updating a question to include an answer filter from saving changes on the entire form )
 
 jobs:
   commit-new-forms:
@@ -40,12 +42,74 @@ jobs:
           git commit -m "Updated form data from Contentful"
           git push origin main
 
-  push-forms-to-staging:
-    name: 🛳 Push forms to S3 (Staging)
+  commit-new-answer-filters:
+    runs-on: ubuntu-latest
+    concurrency: content-commit
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - run: git pull -r
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update answer filter config
+        env:
+          CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
+          CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+        run: npm run import:contentful:answer-filters
+
+      - name: Commit changes
+        continue-on-error: true
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git add config/answerFilters/answerFilters.json
+          git commit -m "Updated answer filters from Contentful"
+          git push origin main
+
+  commit-new-next-steps:
+    runs-on: ubuntu-latest
+    concurrency: content-commit
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - run: git pull -r
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update next step config
+        env:
+          CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
+          CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+        run: npm run import:contentful:next-steps
+
+      - name: Commit changes
+        continue-on-error: true
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git add config/nextSteps/nextStepOptions.json
+          git commit -m "Updated next step options from Contentful"
+          git push origin main
+
+  push-content-to-staging:
+    name: 🛳 Push updated content changes to S3 (Staging)
     runs-on: ubuntu-latest
     concurrency: content-staging
     needs:
       - commit-new-forms
+      - commit-new-answer-filters
+      - commit-new-next-steps
     environment:
       name: Content - Staging
     env:
@@ -58,15 +122,18 @@ jobs:
         uses: actions/checkout@v2
       - run: git pull -r
       - run: aws s3 cp ./config/forms/forms.json "s3://$BUCKET/forms.json"
+      - run: aws s3 cp ./config/answerFilters/answerFilters.json "s3://$BUCKET/answerFilters.json"
+      - run: aws s3 cp ./config/nextSteps/nextStepOptions.json "s3://$BUCKET/nextStepOptions.json"
 
   push-forms-to-production:
     name: 🚀 Push forms to S3 (Production)
+    if: github.event.event_type == 'forms_changed' #Can we access webhook data later down the pipeline?
     runs-on: ubuntu-latest
-    concurrency: content-production
+    concurrency: content-update-forms-production
     needs:
-      - push-forms-to-staging
+      - push-content-to-staging
     environment:
-      name: Content - Production
+      name: Content Update Forms - Production
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
@@ -77,3 +144,43 @@ jobs:
         uses: actions/checkout@v2
       - run: git pull -r
       - run: aws s3 cp ./config/forms/forms.json "s3://$BUCKET/forms.json"
+
+  push-answer-filters-to-production:
+    name: 🚀 Push answer filters to S3 (Production)
+    if: github.event.event_type == 'forms_changed' #Can we access webhook data later down the pipeline?
+    runs-on: ubuntu-latest
+    concurrency: content-update-filters-production
+    needs:
+      - push-content-to-staging
+    environment:
+      name: Content Update Filters - Production
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-west-2
+      BUCKET: ${{ secrets.PRODUCTION_CONTENT_BUCKET }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - run: git pull -r
+      - run: aws s3 cp ./config/answerFilters/answerFilters.json "s3://$BUCKET/answerFilters.json"
+
+  push-next-steps-to-production:
+    name: 🚀 Push next step options to S3 (Production)
+    if: github.event.event_type == 'next_steps_changed' #Can we access webhook data later down the pipeline?
+    runs-on: ubuntu-latest
+    concurrency: content-update-next-steps-production
+    needs:
+      - push-content-to-staging
+    environment:
+      name: Content Update Next Steps - Production
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: eu-west-2
+      BUCKET: ${{ secrets.PRODUCTION_CONTENT_BUCKET }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - run: git pull -r
+      - run: aws s3 cp ./config/nextSteps/nextStepOptions.json "s3://$BUCKET/nextStepOptions.json"

--- a/.github/workflows/upload-content-files.yml
+++ b/.github/workflows/upload-content-files.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Update form and/or filter config
+      - name: Update form and filter config
         if: github.event.event_type == 'forms_changed'
         env:
           CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
           npm run import:contentful:forms
           npm run import:contentful:answer-filters
 
-      - name: Commit form changes
+      - name: Commit form and answer filter changes
         if: github.event.event_type == 'forms_changed'
         continue-on-error: true
         run: |
@@ -43,14 +43,6 @@ jobs:
           git config user.email "<>"
           git add config/forms/forms.json
           git commit -m "Updated form data from Contentful"
-          git push origin main
-
-      - name: Commit answer filter changes
-        if: github.event.event_type == 'forms_changed'
-        continue-on-error: true
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
           git add config/answerFilters/answerFilters.json
           git commit -m "Updated answer filters from Contentful"
           git push origin main
@@ -93,14 +85,14 @@ jobs:
       - run: aws s3 cp ./config/answerFilters/answerFilters.json "s3://$BUCKET/answerFilters.json"
       - run: aws s3 cp ./config/nextSteps/nextStepOptions.json "s3://$BUCKET/nextStepOptions.json"
 
-  push-forms-to-production:
-    name: 🚀 Push forms to S3 (Production)
+  push-forms-and-filters-to-production:
+    name: 🚀 Push forms and answer filters to S3 (Production)
     runs-on: ubuntu-latest
-    concurrency: content-update-forms-production
+    concurrency: content-update-forms-and-filters-production
     needs:
       - push-content-to-staging
     environment:
-      name: Content Update Forms - Production
+      name: Content Update Forms And Answer Filters - Production
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
@@ -111,24 +103,6 @@ jobs:
         uses: actions/checkout@v2
       - run: git pull -r
       - run: aws s3 cp ./config/forms/forms.json "s3://$BUCKET/forms.json"
-
-  push-answer-filters-to-production:
-    name: 🚀 Push answer filters to S3 (Production)
-    runs-on: ubuntu-latest
-    concurrency: content-update-answer-filters-production
-    needs:
-      - push-content-to-staging
-    environment:
-      name: Content Update Answer Filters - Production
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: eu-west-2
-      BUCKET: ${{ secrets.PRODUCTION_CONTENT_BUCKET }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - run: git pull -r
       - run: aws s3 cp ./config/answerFilters/answerFilters.json "s3://$BUCKET/answerFilters.json"
 
   push-next-steps-to-production:

--- a/.github/workflows/upload-content-files.yml
+++ b/.github/workflows/upload-content-files.yml
@@ -7,8 +7,7 @@ on:
       - .github/workflows/upload-content-files.yml
   repository_dispatch:
     types:
-      - forms_changed
-      - next_steps_changed
+      - content_changed
 
 jobs:
   commit-updated-content:
@@ -26,42 +25,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Update form and filter config
-        if: github.event.event_type == 'forms_changed'
+      - name: Update content config i.e forms, answer filters and next steps
         env:
           CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
         run: |
           npm run import:contentful:forms
           npm run import:contentful:answer-filters
+          npm run import:contentful:next-steps
 
-      - name: Commit form and answer filter changes
-        if: github.event.event_type == 'forms_changed'
+      - name: Commit content changes
         continue-on-error: true
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git add config/forms/forms.json
-          git commit -m "Updated form data from Contentful"
           git add config/answerFilters/answerFilters.json
-          git commit -m "Updated answer filters from Contentful"
-          git push origin main
-
-      - name: Update next step config
-        if: github.event.event_type == 'next_steps_changed'
-        env:
-          CONTENTFUL_ACCESS_TOKEN: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
-          CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
-        run: npm run import:contentful:next-steps
-
-      - name: Commit next step changes
-        if: github.event.event_type == 'next_steps_changed'
-        continue-on-error: true
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
           git add config/nextSteps/nextStepOptions.json
-          git commit -m "Updated next step options from Contentful"
+          git commit -m "Updated content data from Contentful"
           git push origin main
 
   push-content-to-staging:
@@ -85,14 +66,14 @@ jobs:
       - run: aws s3 cp ./config/answerFilters/answerFilters.json "s3://$BUCKET/answerFilters.json"
       - run: aws s3 cp ./config/nextSteps/nextStepOptions.json "s3://$BUCKET/nextStepOptions.json"
 
-  push-forms-and-filters-to-production:
-    name: 🚀 Push forms and answer filters to S3 (Production)
+  push-content-to-production:
+    name: 🚀 Push updated content changes to S3 (Production)
     runs-on: ubuntu-latest
-    concurrency: content-update-forms-and-filters-production
+    concurrency: content-production
     needs:
       - push-content-to-staging
     environment:
-      name: Content Update Forms And Answer Filters - Production
+      name: Content - Production
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
@@ -104,22 +85,4 @@ jobs:
       - run: git pull -r
       - run: aws s3 cp ./config/forms/forms.json "s3://$BUCKET/forms.json"
       - run: aws s3 cp ./config/answerFilters/answerFilters.json "s3://$BUCKET/answerFilters.json"
-
-  push-next-steps-to-production:
-    name: 🚀 Push next step options to S3 (Production)
-    runs-on: ubuntu-latest
-    concurrency: content-update-next-steps-production
-    needs:
-      - push-content-to-staging
-    environment:
-      name: Content Update Next Steps - Production
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: eu-west-2
-      BUCKET: ${{ secrets.PRODUCTION_CONTENT_BUCKET }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - run: git pull -r
       - run: aws s3 cp ./config/nextSteps/nextStepOptions.json "s3://$BUCKET/nextStepOptions.json"


### PR DESCRIPTION
Since we already have the setup to deploy changes to the forms automatically. This change would edit the existing pipeline to do the same for changes to next steps & answer filters.

Instead of having separate jobs for updates to next steps, forms and filters, we treat all of them as a 'change to content'. 
We want to avoid the risk of not deploying changes in order.

For example, we need to deploy any 'next steps' updates before deploying an updated form. 
However, if we isolate changes to either next steps, answer filters or forms within a pipeline run, an update to the next steps could exist in one pipeline but not in a subsequent pipeline that might only have the form changes. In this example, we would need to remember to push the next steps pipeline first to production before doing the same for the form, and we run the risk of deploying changes in the wrong order and breaking stuff.

Grouping them as 'content changes' and running all the imports and pushes to S3 regardless of which update was done means we would always get the most recently published version for each. Therefore, reducing the risk of deploying stuff in the wrong order or deploying a pipeline with a missing change.

To Do:
Update Webhook in Contentful
- [ ] Change event type returned 
- [ ] Add filters so that Webhook is not triggered for changes outside of next steps, answer filters and forms.