### PR TITLE
Feat/audit tables

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -91,7 +91,7 @@ jobs:
           postgresql password: "postgres"
 
       - name: Setup Database
-        run: npm run db:push
+        run: node_modules/.bin/prisma migrate deploy
 
       - name: Build app
         run: npm run build

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -107,7 +107,7 @@ jobs:
           postgresql password: "postgres"
 
       - name: Setup Database
-        run: npm run db:push
+        run: node_modules/.bin/prisma migrate deploy
 
       - name: Build app
         run: npm run build

--- a/prisma/migrations/20220216101144_add_auditing_to_comments_table/migration.sql
+++ b/prisma/migrations/20220216101144_add_auditing_to_comments_table/migration.sql
@@ -1,0 +1,34 @@
+-- Add Comment_Audit table along with trigger for this table
+CREATE TABLE "Comment_Audit"
+(
+    operation char(20) NOT NULL,
+    timestamp timestamp DEFAULT CURRENT_TIMESTAMP,
+    id        text     NOT NULL,
+    before    JSONB    NOT NULL,
+    after     JSONB    NOT NULL
+);
+
+CREATE OR REPLACE FUNCTION Comment_Audit_Trigger() RETURNS TRIGGER AS
+$Comment_Audit$
+BEGIN
+    IF (TG_OP = 'DELETE') THEN
+        INSERT INTO "Comment_Audit" (operation, id, before, after)
+        VALUES ('DELETE', old.id, TO_JSONB(old), '"null"');
+    ELSIF (TG_OP = 'INSERT') THEN
+        INSERT INTO "Comment_Audit" (operation, id, before, after)
+        VALUES ('INSERT', new.id, '"null"', TO_JSONB(new));
+    ELSIF (TG_OP = 'UPDATE') THEN
+        IF OLD IS DISTINCT FROM NEW THEN
+            INSERT INTO "Comment_Audit" (operation, id, before, after)
+            VALUES ('UPDATE', old.id, TO_JSONB(old), TO_JSONB(new));
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$Comment_Audit$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "When_Comment_Table_Changes"
+    AFTER INSERT OR UPDATE OR DELETE
+    ON "Comment"
+    FOR EACH ROW
+EXECUTE PROCEDURE Comment_Audit_Trigger();

--- a/prisma/migrations/20220216101544_add_auditing_to_next_steps_table/migration.sql
+++ b/prisma/migrations/20220216101544_add_auditing_to_next_steps_table/migration.sql
@@ -1,0 +1,34 @@
+-- Add NextStep_Audit table along with trigger for this table
+CREATE TABLE "NextStep_Audit"
+(
+    operation char(20) NOT NULL,
+    timestamp timestamp DEFAULT CURRENT_TIMESTAMP,
+    id        text     NOT NULL,
+    before    JSONB    NOT NULL,
+    after     JSONB    NOT NULL
+);
+
+CREATE OR REPLACE FUNCTION NextStep_Audit_Trigger() RETURNS TRIGGER AS
+$NextStep_Audit$
+BEGIN
+    IF (TG_OP = 'DELETE') THEN
+        INSERT INTO "NextStep_Audit" (operation, id, before, after)
+        VALUES ('DELETE', old.id, TO_JSONB(old), '"null"');
+    ELSIF (TG_OP = 'INSERT') THEN
+        INSERT INTO "NextStep_Audit" (operation, id, before, after)
+        VALUES ('INSERT', new.id, '"null"', TO_JSONB(new));
+    ELSIF (TG_OP = 'UPDATE') THEN
+        IF OLD IS DISTINCT FROM NEW THEN
+            INSERT INTO "NextStep_Audit" (operation, id, before, after)
+            VALUES ('UPDATE', old.id, TO_JSONB(old), TO_JSONB(new));
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$NextStep_Audit$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "When_NextStep_Table_Changes"
+    AFTER INSERT OR UPDATE OR DELETE
+    ON "NextStep"
+    FOR EACH ROW
+EXECUTE PROCEDURE NextStep_Audit_Trigger();

--- a/prisma/migrations/20220216104243_add_auditing_to_workflow_table/migration.sql
+++ b/prisma/migrations/20220216104243_add_auditing_to_workflow_table/migration.sql
@@ -1,0 +1,35 @@
+-- Add Workflow_Audit table along with trigger for this table
+CREATE TABLE "Workflow_Audit"
+(
+    operation char(20) NOT NULL,
+    timestamp timestamp DEFAULT CURRENT_TIMESTAMP,
+    id        text     NOT NULL,
+    before    JSONB    NOT NULL,
+    after     JSONB    NOT NULL
+);
+
+CREATE OR REPLACE FUNCTION Workflow_Audit_Trigger() RETURNS TRIGGER AS
+$Workflow_Audit$
+BEGIN
+    IF (TG_OP = 'DELETE') THEN
+        INSERT INTO "Workflow_Audit" (operation, id, before, after)
+        VALUES ('DELETE', old.id, TO_JSONB(old), '"null"');
+    ELSIF (TG_OP = 'INSERT') THEN
+        INSERT INTO "Workflow_Audit" (operation, id, before, after)
+        VALUES ('INSERT', new.id, '"null"', TO_JSONB(new));
+    ELSIF (TG_OP = 'UPDATE') THEN
+        old."updatedAt" = new."updatedAt";
+        IF OLD IS DISTINCT FROM NEW THEN
+            INSERT INTO "Workflow_Audit" (operation, id, before, after)
+            VALUES ('UPDATE', old.id, TO_JSONB(old), TO_JSONB(new));
+        END IF;
+    END IF;
+    RETURN NULL;
+END;
+$Workflow_Audit$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "When_Workflow_Table_Changes"
+    AFTER INSERT OR UPDATE OR DELETE
+    ON "Workflow"
+    FOR EACH ROW
+EXECUTE PROCEDURE Workflow_Audit_Trigger();


### PR DESCRIPTION
## What?

Add auditing on SQL UPDATE DELETE AND INSERT for the following tables:

* Comment
* Workflow
* Next Step

And update cypress pipeline tests to run the db migrations rather than just pushing the DB schema.

## Why?

So we can audit changes to the above tables over time without loosing data.

## How?

Add table triggers for UPDATE INSERT DELETE with data being stored in the audit table.