### PR TITLE
feat: api endpoint for brokerage

### DIFF
--- a/pages/api/workflows/[id]/index.ts
+++ b/pages/api/workflows/[id]/index.ts
@@ -1,13 +1,26 @@
 import prisma from "../../../../lib/prisma"
 import {NextApiRequest, NextApiResponse} from "next"
-import { apiHandler } from "../../../../lib/apiHelpers"
-import { middleware as csrfMiddleware } from '../../../../lib/csrfToken';
+import {apiHandler} from "../../../../lib/apiHelpers"
+import {middleware as csrfMiddleware} from '../../../../lib/csrfToken';
+import answerFilters from "../../../../config/answerFilters";
 
 export const handler = async (req: NextApiRequest, res: NextApiResponse): Promise<void> => {
-  const { id } = req.query
+  const {id} = req.query
 
   switch (req.method) {
     case "GET": {
+      const {filter} = req.query
+      if (filter) {
+        const validFilters = answerFilters.map(f => f.id);
+
+        if (!validFilters.includes(filter as string)) {
+          res.status(400)
+            .json({error: `${filter} is not a valid filter, must be one of ${validFilters.join(', ')}`})
+
+          return;
+        }
+      }
+
       const workflow = await prisma.workflow.findUnique({
         where: {
           id: id as string,
@@ -43,7 +56,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse): Promis
     }
 
     default: {
-      res.status(405).json({ error: `${req.method} not supported on this endpoint` })
+      res.status(405).json({error: `${req.method} not supported on this endpoint`})
     }
   }
 }

--- a/pagesTest/api/workflows/[id]/index.test.ts
+++ b/pagesTest/api/workflows/[id]/index.test.ts
@@ -46,5 +46,27 @@ describe('pages/api/workflows/[id]', () => {
     test('returns the full workflow data', () => {
       expect(response.json).toHaveBeenCalledWith({workflow: mockWorkflow})
     })
+
+    describe('with filtering', () => {
+      describe('an invalid filter', function () {
+        beforeAll(async () => {
+          await handler(makeNextApiRequest({
+            url: '/api/workflows/mock-workflow',
+            query: {id: 'mock-workflow', filter: 'invalid-filter'},
+            session: mockSession,
+          }), response);
+        })
+
+        test('gives a request error status', () => {
+          expect(response.status).toHaveBeenCalledWith(400)
+        })
+
+        test('returns an error detailing the invalid filter', () => {
+          expect(response.json).toHaveBeenCalledWith({
+            error: 'invalid-filter is not a valid filter, must be one of direct-payments, brokerage',
+          })
+        })
+      });
+    });
   });
 })

--- a/pagesTest/api/workflows/[id]/index.test.ts
+++ b/pagesTest/api/workflows/[id]/index.test.ts
@@ -5,6 +5,21 @@ import {makeNextApiRequest, testApiHandlerUnsupportedMethods} from "../../../../
 import {handler} from "../../../../pages/api/workflows/[id]";
 import {mockSession} from "../../../../fixtures/session";
 
+const mockWorkflowWithAnswers = {
+  ...mockWorkflow,
+  answers: {
+    "Theme": {
+      "Question One": "",
+      "Question Two": "",
+    },
+  },
+}
+
+jest.mock("../../../../config/answerFilters", () => ([{
+  id: "mock-filter",
+  label: "Mock Filter",
+  answers: { "Theme": ["Question One"] },
+}]))
 jest.mock("../../../../lib/prisma", () => ({
   nextStep: {
     deleteMany: jest.fn()
@@ -19,13 +34,15 @@ const response = {
   json: jest.fn(),
 } as unknown as NextApiResponse
 
-;(prisma.workflow.findUnique as jest.Mock).mockResolvedValue(mockWorkflow);
+;(prisma.workflow.findUnique as jest.Mock).mockResolvedValue(mockWorkflowWithAnswers);
 
 describe('pages/api/workflows/[id]', () => {
   testApiHandlerUnsupportedMethods(handler, ["GET", "PATCH", "DELETE"])
 
   describe('retrieving a workflow', () => {
     beforeAll(async () => {
+      ;(response.status as jest.Mock).mockClear()
+      ;(response.json as jest.Mock).mockClear()
       await handler(makeNextApiRequest({
         url: '/api/workflows/mock-workflow',
         query: { id: 'mock-workflow' },
@@ -44,12 +61,14 @@ describe('pages/api/workflows/[id]', () => {
     })
 
     test('returns the full workflow data', () => {
-      expect(response.json).toHaveBeenCalledWith({workflow: mockWorkflow})
+      expect(response.json).toHaveBeenCalledWith({workflow: mockWorkflowWithAnswers})
     })
 
     describe('with filtering', () => {
       describe('an invalid filter', function () {
         beforeAll(async () => {
+          ;(response.status as jest.Mock).mockClear()
+          ;(response.json as jest.Mock).mockClear()
           await handler(makeNextApiRequest({
             url: '/api/workflows/mock-workflow',
             query: {id: 'mock-workflow', filter: 'invalid-filter'},
@@ -63,7 +82,36 @@ describe('pages/api/workflows/[id]', () => {
 
         test('returns an error detailing the invalid filter', () => {
           expect(response.json).toHaveBeenCalledWith({
-            error: 'invalid-filter is not a valid filter, must be one of direct-payments, brokerage',
+            error: 'invalid-filter is not a valid filter, must be one of mock-filter',
+          })
+        })
+      });
+
+      describe('a known mock filter', () => {
+        beforeAll(async () => {
+          ;(response.status as jest.Mock).mockClear()
+          ;(response.json as jest.Mock).mockClear()
+          await handler(makeNextApiRequest({
+            url: '/api/workflows/mock-workflow',
+            query: {id: 'mock-workflow', filter: 'mock-filter'},
+            session: mockSession,
+          }), response);
+        })
+
+        test('gives a request error status', () => {
+          expect(response.status).toHaveBeenCalledWith(200)
+        })
+
+        test('returns an error detailing the invalid filter', () => {
+          expect(response.json).toHaveBeenCalledWith({
+            workflow: {
+              ...mockWorkflowWithAnswers,
+              answers: {
+                "Theme": {
+                  "Question One": "",
+                },
+              },
+            },
           })
         })
       });


### PR DESCRIPTION
## What?

Allow filtering workflow answers on the `/api/workflows/[id]` endpoint.

## Why?

So that interacting APIs can pull only information that is relevant to them.

## How?

Use the same process in place for filtering on the frontend.
