### PR TITLE
Handle Null Names on Planner Page

### DIFF
--- a/components/AssignmentWidget.test.tsx
+++ b/components/AssignmentWidget.test.tsx
@@ -337,4 +337,72 @@ describe("AssignmentWidget", () => {
       expect(screen.queryByText("Reassign")).not.toBeInTheDocument()
     })
   })
+
+  describe("when a user has no name", () => {
+    it("displays the user's email instead of their name", async () => {
+      ; (useAssignment as jest.Mock).mockReturnValue({
+        data: {
+          assignee: null,
+          assignedTeam: null,
+        },
+      })
+
+        ; (useUsers as jest.Mock).mockReturnValue({
+          data: [
+            {
+              ...mockUser,
+              id: "2abc",
+              name: "John Access",
+              team: Team.Access,
+            },
+            {
+              ...mockUser,
+              id: "1abc",
+              name: "",
+              team: Team.Access,
+              email: "test.test@test.com"
+            },
+            {
+              ...mockUser,
+              id: "3abc",
+              name: null,
+              team: Team.Review,
+            },
+            {
+              ...mockUser,
+              id: "4abc",
+              name: "John No Team",
+              team: null,
+            },
+          ],
+        })
+
+      renderWidget();
+
+      await waitFor(() => {
+        fireEvent.click(screen.getByText("Assign someone?"))
+      })
+
+      const usersDropdown = screen.getByRole("combobox", {
+        name: /Assign to a user/,
+      })
+      const usersDropdownOptions = usersDropdown.childNodes
+
+      expect(usersDropdownOptions).toHaveLength(4)
+      expect(usersDropdownOptions[0]).toHaveTextContent("Unassigned")
+      expect(usersDropdownOptions[1].childNodes[0]).toHaveTextContent(
+        "John Access"
+      )
+      expect(usersDropdownOptions[1].childNodes[1]).toHaveTextContent(
+        "test.test@test.com"
+      )
+      expect(usersDropdownOptions[2].childNodes[0]).toHaveTextContent(
+        "firstname.surname@hackney.gov.uk"
+      )
+      expect(usersDropdownOptions[3].childNodes[0]).toHaveTextContent(
+        "John No Team"
+      )
+
+    })
+  })
 })

--- a/components/NewDashboard/KanbanCard.test.tsx
+++ b/components/NewDashboard/KanbanCard.test.tsx
@@ -42,7 +42,7 @@ describe("components/NewDashboard/KanbanCard", () => {
   })
 
   describe("render with missing information", () => {
-    test("displays the KanbanCard when the assigned user has null as name", () => {
+    test("displays the KanbanCard using the initials from the email address when the assigned user has null as name", () => {
       const workflowNullAssigneeName = {
         ...mockWorkflowWithExtras,
         assignee: {
@@ -61,7 +61,7 @@ describe("components/NewDashboard/KanbanCard", () => {
       expect(screen.getByText("TS")).toBeVisible()
     })
 
-    test("displays the KanbanCard when the assigned user has empty string as name", () => {
+    test("displays the KanbanCard using the initials from the email address when the assigned user has empty string as name", () => {
       const workflowNullAssigneeName = {
         ...mockWorkflowWithExtras,
         assignee: {
@@ -79,7 +79,7 @@ describe("components/NewDashboard/KanbanCard", () => {
       expect(screen.getByText("TS")).toBeVisible()
     })
 
-    test("displays the KanbanCard when the assigned user has null as name and no email address", () => {
+    test("displays the KanbanCard with ?? instead of initials when the assigned user has null as name and no email address", () => {
       const workflowNullAssigneeName = {
         ...mockWorkflowWithExtras,
         assignee: {

--- a/components/NewDashboard/KanbanCard.test.tsx
+++ b/components/NewDashboard/KanbanCard.test.tsx
@@ -96,5 +96,20 @@ describe("components/NewDashboard/KanbanCard", () => {
       )
       expect(screen.getByText("??")).toBeVisible()
     })
+
+    test("displays the kanban card when no one is assigned to a workflow", () => {
+      const workflowNullAssignee = {
+        ...mockWorkflowWithExtras,
+        assignee: null
+      }
+
+      renderWithSession(
+        <KanbanCard
+          workflow={workflowNullAssignee}
+          status={Status.InProgress}
+        />
+      )
+      expect(screen.getByText("Resident Firstname Resident Surname")).toBeVisible()
+    })
   })
 })

--- a/components/NewDashboard/KanbanCard.test.tsx
+++ b/components/NewDashboard/KanbanCard.test.tsx
@@ -1,36 +1,100 @@
-import {describe, test} from "@jest/globals";
-import {screen} from "@testing-library/react";
-import {
-  mockWorkflowWithExtras
-} from "../../fixtures/workflows";
-import {Status} from "../../types";
-import KanbanCard from "./KanbanCard";
-import {renderWithSession} from "../../lib/auth/test-functions";
-import useResident from "../../hooks/useResident";
-import {mockResident} from "../../fixtures/residents";
+import { describe, test } from "@jest/globals"
+import { screen } from "@testing-library/react"
+import { mockWorkflowWithExtras } from "../../fixtures/workflows"
+import { Status } from "../../types"
+import KanbanCard from "./KanbanCard"
+import { renderWithSession } from "../../lib/auth/test-functions"
+import useResident from "../../hooks/useResident"
+import { mockResident } from "../../fixtures/residents"
+import { mockUser } from "../../fixtures/users"
 
-jest.mock('../../hooks/useResident');
-(useResident as jest.Mock).mockReturnValue({
+jest.mock("../../hooks/useResident")
+;(useResident as jest.Mock).mockReturnValue({
   data: mockResident,
 })
 
 describe("components/NewDashboard/KanbanCard", () => {
-  describe('an in-progress status', () => {
+  describe("an in-progress status", () => {
     beforeEach(() =>
-      renderWithSession(<KanbanCard workflow={mockWorkflowWithExtras} status={Status.InProgress}/>)
-    );
+      renderWithSession(
+        <KanbanCard
+          workflow={mockWorkflowWithExtras}
+          status={Status.InProgress}
+        />
+      )
+    )
 
-    test('displays a link to the workflow', () => {
-      expect(screen.getByText('Resident Firstname Resident Surname').closest('a'))
-        .toHaveAttribute('href', `/workflows/${mockWorkflowWithExtras.id}`);
-    });
+    test("displays a link to the workflow", () => {
+      expect(
+        screen.getByText("Resident Firstname Resident Surname").closest("a")
+      ).toHaveAttribute("href", `/workflows/${mockWorkflowWithExtras.id}`)
+    })
 
-    test('displays the residents name', () => {
-      expect(screen.getByText('Resident Firstname Resident Surname')).toBeVisible();
-    });
+    test("displays the residents name", () => {
+      expect(
+        screen.getByText("Resident Firstname Resident Surname")
+      ).toBeVisible()
+    })
 
-    test('displays the workflow form type', () => {
-      expect(screen.getByText(/Mock form/)).toBeVisible();
-    });
-  });
+    test("displays the workflow form type", () => {
+      expect(screen.getByText(/Mock form/)).toBeVisible()
+    })
+  })
+
+  describe("render with missing information", () => {
+    test("displays the KanbanCard when the assigned user has null as name", () => {
+      const workflowNullAssigneeName = {
+        ...mockWorkflowWithExtras,
+        assignee: {
+          ...mockUser,
+          name: null,
+          email: "test.surname@hackney.gov.uk",
+        },
+      }
+      renderWithSession(
+        <KanbanCard
+          workflow={workflowNullAssigneeName}
+          status={Status.InProgress}
+        />
+      )
+
+      expect(screen.getByText("TS")).toBeVisible()
+    })
+
+    test("displays the KanbanCard when the assigned user has empty string as name", () => {
+      const workflowNullAssigneeName = {
+        ...mockWorkflowWithExtras,
+        assignee: {
+          ...mockUser,
+          name: "",
+          email: "test.surname@hackney.gov.uk",
+        },
+      }
+      renderWithSession(
+        <KanbanCard
+          workflow={workflowNullAssigneeName}
+          status={Status.InProgress}
+        />
+      )
+      expect(screen.getByText("TS")).toBeVisible()
+    })
+
+    test("displays the KanbanCard when the assigned user has null as name and no email address", () => {
+      const workflowNullAssigneeName = {
+        ...mockWorkflowWithExtras,
+        assignee: {
+          ...mockUser,
+          name: "",
+          email: "",
+        },
+      }
+      renderWithSession(
+        <KanbanCard
+          workflow={workflowNullAssigneeName}
+          status={Status.InProgress}
+        />
+      )
+      expect(screen.getByText("??")).toBeVisible()
+    })
+  })
 })

--- a/components/NewDashboard/KanbanCard.tsx
+++ b/components/NewDashboard/KanbanCard.tsx
@@ -1,6 +1,7 @@
 import s from "./KanbanCard.module.scss"
 import Link from "next/link"
 import {
+  emailInitials,
   prettyDate,
   prettyResidentName,
   userInitials,
@@ -25,7 +26,7 @@ const KanbanCard = ({ workflow, status }: Props): React.ReactElement => {
 
   const mine = session?.email === workflow?.assignee?.email
   const showUrgent = workflow.heldAt && status !== Status.NoAction
-
+  const initials  = userInitials(workflow.assignee.name) || emailInitials(workflow.assignee.email);
   return (
     <li
       className={`${s.outer} ${
@@ -65,7 +66,7 @@ const KanbanCard = ({ workflow, status }: Props): React.ReactElement => {
               mine ? ` (you)` : ""
             }`}
           >
-            {userInitials(workflow.assignee.name)}
+            {initials}
           </div>
         )}
       </footer>

--- a/components/NewDashboard/KanbanCard.tsx
+++ b/components/NewDashboard/KanbanCard.tsx
@@ -26,7 +26,9 @@ const KanbanCard = ({ workflow, status }: Props): React.ReactElement => {
 
   const mine = session?.email === workflow?.assignee?.email
   const showUrgent = workflow.heldAt && status !== Status.NoAction
-  const initials  = userInitials(workflow.assignee.name) || emailInitials(workflow.assignee.email);
+  const initials =
+    userInitials(workflow?.assignee?.name) ||
+    emailInitials(workflow?.assignee?.email)
   return (
     <li
       className={`${s.outer} ${

--- a/components/UserSelect.tsx
+++ b/components/UserSelect.tsx
@@ -39,7 +39,7 @@ const UserOptions = ({
             <optgroup label={prettyTeamNames[team] || "No team"} key={team}>
               {users.map(opt => (
                 <option key={opt.id} value={opt.email}>
-                  {opt.name}
+                  {opt.name || opt.email}
                 </option>
               ))}
             </optgroup>

--- a/lib/formatters.test.ts
+++ b/lib/formatters.test.ts
@@ -3,14 +3,14 @@ import localNextStepOptions from "../config/nextSteps/nextStepOptions.json"
 
 import {
   displayEditorNames,
-  displayEthnicity,
+  displayEthnicity, emailInitials,
   prettyDate,
   prettyDateAndTime,
   prettyDateToNow,
   prettyGmailMessage,
   prettyNextSteps,
   prettyResidentName,
-  truncate,
+  truncate, userInitials,
 } from "./formatters"
 
 jest
@@ -173,6 +173,14 @@ describe("displayEthnicity", () => {
   })
 })
 
+describe("userInitials", () => {
+  it("properly splits a name String into initials", () => {
+    const actual = userInitials("Olatokunbo Koiki ")
+    const expected = "OK"
+    expect(actual).toBe(expected)
+  })
+})
+
 describe("prettyGmailMessage", () => {
   it("correctly formats a message", () => {
     const result = prettyGmailMessage({
@@ -190,5 +198,20 @@ describe("prettyGmailMessage", () => {
   ---
   eyup
   ---`)
+  })
+})
+
+describe("emailInitials", () => {
+  it("ascertains initials from email address", () => {
+    expect(emailInitials("Phoenix.Ryder@hackney.gov.uk")). toBe("PR")
+  })
+
+  it("ascertains single initial from email address", () => {
+    expect(emailInitials("Phoenix@hackney.gov.uk")). toBe("P")
+  })
+
+  it("returns empty string when falsey email supplied", () => {
+    expect(emailInitials("")). toBe("??")
+    expect(emailInitials(null)). toBe("??")
   })
 })

--- a/lib/formatters.test.ts
+++ b/lib/formatters.test.ts
@@ -3,14 +3,16 @@ import localNextStepOptions from "../config/nextSteps/nextStepOptions.json"
 
 import {
   displayEditorNames,
-  displayEthnicity, emailInitials,
+  displayEthnicity,
+  emailInitials,
   prettyDate,
   prettyDateAndTime,
   prettyDateToNow,
   prettyGmailMessage,
   prettyNextSteps,
   prettyResidentName,
-  truncate, userInitials,
+  truncate,
+  userInitials,
 } from "./formatters"
 
 jest
@@ -179,6 +181,14 @@ describe("userInitials", () => {
     const expected = "OK"
     expect(actual).toBe(expected)
   })
+  it("returns single initial if single name is passed", () => {
+    expect(userInitials("Phoenix")).toBe("P")
+  })
+
+  it("returns null when falsey name supplied", () => {
+    expect(userInitials("")).toBeNull()
+    expect(userInitials(null)).toBeNull()
+  })
 })
 
 describe("prettyGmailMessage", () => {
@@ -203,15 +213,15 @@ describe("prettyGmailMessage", () => {
 
 describe("emailInitials", () => {
   it("ascertains initials from email address", () => {
-    expect(emailInitials("Phoenix.Ryder@hackney.gov.uk")). toBe("PR")
+    expect(emailInitials("Phoenix.Ryder@hackney.gov.uk")).toBe("PR")
   })
 
   it("ascertains single initial from email address", () => {
-    expect(emailInitials("Phoenix@hackney.gov.uk")). toBe("P")
+    expect(emailInitials("Phoenix@hackney.gov.uk")).toBe("P")
   })
 
   it("returns empty string when falsey email supplied", () => {
-    expect(emailInitials("")). toBe("??")
-    expect(emailInitials(null)). toBe("??")
+    expect(emailInitials("")).toBe("??")
+    expect(emailInitials(null)).toBe("??")
   })
 })

--- a/lib/formatters.test.ts
+++ b/lib/formatters.test.ts
@@ -177,8 +177,8 @@ describe("displayEthnicity", () => {
 
 describe("userInitials", () => {
   it("properly splits a name String into initials", () => {
-    const actual = userInitials("Olatokunbo Koiki ")
-    const expected = "OK"
+    const actual = userInitials("Phoenix Ryder ")
+    const expected = "PR"
     expect(actual).toBe(expected)
   })
   it("returns single initial if single name is passed", () => {

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -80,11 +80,25 @@ export const prettyNextSteps = (
 }
 
 export const userInitials = (name: string): string => {
-  const names = name.split(" ")
-  return names
-    .map(name => name[0])
-    .join("")
-    .toUpperCase()
+  if (name) {
+    const names = name.split(" ")
+    return names
+      .map(name => name[0])
+      .join("")
+      .toUpperCase()
+  }
+  return null
+}
+
+export const emailInitials = (email : string): string => {
+  if (email) {
+    const names = email.split("@")[0].split(".")
+    return names
+      .map(name => name[0])
+      .join("")
+      .toUpperCase()
+  }
+  return "??"
 }
 
 /** Returns the description of an ethnicity from a code */

--- a/pages/workflows/[id]/finish.tsx
+++ b/pages/workflows/[id]/finish.tsx
@@ -52,7 +52,7 @@ const FinishWorkflowPage = ({ workflow, forms }: Props): React.ReactElement => {
     users
       ?.filter(user => user.approver)
       ?.map(user => ({
-        label: `${user.name} (${user.email})`,
+        label: user.name ? `${user.name} (${user.email})` : `${user.email}`,
         value: user.email,
       })) || []
   )
@@ -249,14 +249,14 @@ const FinishWorkflowPage = ({ workflow, forms }: Props): React.ReactElement => {
               )}
 
               {isUnlinked && (
-              <SelectField
-                name="workflowId"
-                label="Is this linked to any of this resident's earlier assessments?"
-                hint="This doesn't include reassessments"
-                touched={touched}
-                errors={errors}
-                choices={workflowChoices}
-              />
+                <SelectField
+                  name="workflowId"
+                  label="Is this linked to any of this resident's earlier assessments?"
+                  hint="This doesn't include reassessments"
+                  touched={touched}
+                  errors={errors}
+                  choices={workflowChoices}
+                />
               )}
               {isApprovable &&
                 <SelectField

--- a/pagesTest/workflows/[id]/finish.test.tsx
+++ b/pagesTest/workflows/[id]/finish.test.tsx
@@ -227,7 +227,7 @@ describe("<FinishWorkflowPage />", () => {
       expect(screen.getByText("Firstname Surname (firstname.surname@hackney.gov.uk)")).toBeVisible()
     })
 
-    it.only("displays the approvers email if they have no name", async () => {
+    it("displays the approvers email if they have no name", async () => {
       ; (useUsers as jest.Mock).mockReturnValue({
         data: [{ ...mockApprover, name: null }],
       })

--- a/pagesTest/workflows/[id]/finish.test.tsx
+++ b/pagesTest/workflows/[id]/finish.test.tsx
@@ -31,7 +31,7 @@ import { mockApprover } from "../../../fixtures/users"
 import { screeningFormId } from "../../../config"
 import useNextSteps from "../../../hooks/useNextSteps"
 import { mockNextStepOptions } from "../../../fixtures/nextStepOptions"
-import {beforeEach} from "@jest/globals";
+import { beforeEach } from "@jest/globals";
 
 jest.mock("../../../lib/prisma", () => ({
   workflow: {
@@ -40,49 +40,49 @@ jest.mock("../../../lib/prisma", () => ({
 }))
 
 jest.mock("../../../lib/residents")
-;(getResidentById as jest.Mock).mockResolvedValue(mockResident)
+  ; (getResidentById as jest.Mock).mockResolvedValue(mockResident)
 
 jest.mock("../../../lib/auth/session")
-;(getSession as jest.Mock).mockResolvedValue(mockSession)
+  ; (getSession as jest.Mock).mockResolvedValue(mockSession)
 
 jest.mock("next/router")
-;(useRouter as jest.Mock).mockReturnValue({
-  query: { id: mockWorkflow.id },
-  push: jest.fn(),
-})
+  ; (useRouter as jest.Mock).mockReturnValue({
+    query: { id: mockWorkflow.id },
+    push: jest.fn(),
+  })
 
 jest.mock("../../../components/_Layout")
-;(Layout as jest.Mock).mockImplementation(({ children }) => <>{children}</>)
+  ; (Layout as jest.Mock).mockImplementation(({ children }) => <>{children}</>)
 
 jest.mock("../../../hooks/useResident")
-;(useResident as jest.Mock).mockReturnValue({ data: mockResident })
+  ; (useResident as jest.Mock).mockReturnValue({ data: mockResident })
 
 jest.mock("../../../hooks/useUsers")
-;(useUsers as jest.Mock).mockReturnValue({
-  data: [mockApprover],
-})
+  ; (useUsers as jest.Mock).mockReturnValue({
+    data: [mockApprover],
+  })
 
 jest.mock("../../../hooks/useWorkflowsByResident")
-;(useWorkflowsByResident as jest.Mock).mockReturnValue({
-  data: {
-    workflows: [
-      {
-        ...mockWorkflow,
-        id: "098zyx",
-        updatedAt: new Date(
-          "January 25, 2022 14:00:00"
-        ).toISOString() as unknown as Date,
-        formId: "Guided meditation",
-      },
-    ],
-  },
-})
+  ; (useWorkflowsByResident as jest.Mock).mockReturnValue({
+    data: {
+      workflows: [
+        {
+          ...mockWorkflow,
+          id: "098zyx",
+          updatedAt: new Date(
+            "January 25, 2022 14:00:00"
+          ).toISOString() as unknown as Date,
+          formId: "Guided meditation",
+        },
+      ],
+    },
+  })
 
 jest.mock("../../../hooks/useNextSteps")
 const mockNextSteps = {
-    options: mockNextStepOptions,
-  }
-;(useNextSteps as jest.Mock).mockReturnValue({ data: mockNextSteps })
+  options: mockNextStepOptions,
+}
+  ; (useNextSteps as jest.Mock).mockReturnValue({ data: mockNextSteps })
 
 global.fetch = jest.fn().mockResolvedValue({ json: jest.fn() })
 
@@ -92,7 +92,7 @@ document.head.insertAdjacentHTML(
 )
 
 beforeEach(() => {
-  ;(fetch as jest.Mock).mockClear()
+  ; (fetch as jest.Mock).mockClear()
 })
 
 describe("page/workflows/[id]/finish.getServerSideProps", () => {
@@ -154,7 +154,7 @@ describe("page/workflows/[id]/finish.getServerSideProps", () => {
     let response
 
     beforeAll(async () => {
-      ;(prisma.workflow.findUnique as jest.Mock).mockResolvedValue(null)
+      ; (prisma.workflow.findUnique as jest.Mock).mockResolvedValue(null)
 
       response = await getServerSideProps(
         makeGetServerSidePropsContext({
@@ -179,7 +179,7 @@ describe("page/workflows/[id]/finish.getServerSideProps", () => {
     let response
 
     beforeAll(async () => {
-      ;(prisma.workflow.findUnique as jest.Mock).mockResolvedValue({
+      ; (prisma.workflow.findUnique as jest.Mock).mockResolvedValue({
         ...mockWorkflowWithExtras,
         submittedAt: new Date(),
       })
@@ -219,6 +219,33 @@ describe("<FinishWorkflowPage />", () => {
         screen.getByRole("heading", { level: 1, name: "Next steps and approval" })
       ).toBeVisible()
     })
+
+    it("displays a list of approvers", async () => {
+      await waitFor(() => fireEvent.click(screen.getByRole("combobox", {
+        name: /Who should approve this?/,
+      })))
+      expect(screen.getByText("Firstname Surname (firstname.surname@hackney.gov.uk)")).toBeVisible()
+    })
+
+    it.only("displays the approvers email if they have no name", async () => {
+      ; (useUsers as jest.Mock).mockReturnValue({
+        data: [{ ...mockApprover, name: null }],
+      })
+
+      render(
+        <FinishWorkflowPage
+          workflow={{ ...mockWorkflowWithExtras, form: mockForm }}
+          forms={mockForms}
+        />
+      )
+
+      await waitFor(() => fireEvent.click(screen.getByRole("combobox", {
+        name: /Who should approve this?/,
+      })))
+
+      expect(screen.getByText("firstname.surname@hackney.gov.uk")).toBeVisible()
+    })
+
     describe("when a review date isn't chosen", () => {
       it("displays an error", async () => {
         await waitFor(() => fireEvent.click(screen.getByText("Finish and send")))
@@ -386,7 +413,7 @@ describe("<FinishWorkflowPage />", () => {
     const linkedWorkflowSelection = screen.getByLabelText(
       "Is this linked to any of this resident's earlier assessments?"
     )
-    fireEvent.change(linkedWorkflowSelection, {target: {value: "098zyx"}})
+    fireEvent.change(linkedWorkflowSelection, { target: { value: "098zyx" } })
     await waitFor(() => {
       fireEvent.click(screen.getByText("Finish and send"))
     })
@@ -399,7 +426,7 @@ describe("<FinishWorkflowPage />", () => {
         nextSteps: [],
       }),
       method: "POST",
-      headers: {"XSRF-TOKEN": "test"},
+      headers: { "XSRF-TOKEN": "test" },
     })
   })
 })


### PR DESCRIPTION
**What**
Updated code that is used on the planner page to handle when a users name is null

**Why**
There are users within the system where the name field is null, this seems to happen when a users does not have a name set in google when they first log in to the system